### PR TITLE
Player-client split and refactor

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -430,29 +430,29 @@ bool Client::HandleLoginRequest() {
 	);
 
 	// Spawn the other players for the new client
-	/*
-    for (Player* others : Betrock::Server::Instance().GetConnectedPlayers()) {
-		if (others == player) { continue; }
+    for (auto other : Betrock::Server::Instance().GetConnectedClients()) {
+		if (other.get() == this) { continue; }
+		auto otherPlayer = other->GetPlayer();
 		Respond::NamedEntitySpawn(
 			response,
-			others->entityId,
-			others->username,
-			Vec3ToInt3(others->position),
-			others->yaw,
-			others->pitch,
-			others->inventory[others->GetHotbarSlot()].id
+			otherPlayer->entityId,
+			otherPlayer->username,
+			Vec3ToInt3(otherPlayer->position),
+			otherPlayer->yaw,
+			otherPlayer->pitch,
+			other->GetHeldItem().id
 		);
 		
 		// Apparently needed to entities show up where they need to
 		Respond::EntityTeleport(
 			response,
-			others->entityId,
-			Vec3ToEntityInt3(others->position),
-			ConvertFloatToPackedByte(others->yaw),
-			ConvertFloatToPackedByte(others->pitch)
+			otherPlayer->entityId,
+			Vec3ToEntityInt3(otherPlayer->position),
+			ConvertFloatToPackedByte(otherPlayer->yaw),
+			ConvertFloatToPackedByte(otherPlayer->pitch)
 		);
 
-    }*/
+    }
 	Respond::ChatMessage(response, std::string("This Server runs on ") + std::string(PROJECT_NAME_VERSION));
 	SendResponse(true);
 	// ONLY SET THIS AFTER LOGIN HAS FINISHED
@@ -774,7 +774,10 @@ bool Client::HandleDisconnect(std::string disconnectMessage) {
 }
 
 void Client::AppendResponse(std::vector<uint8_t> &addition) {
+	//Betrock::Logger::Instance().Debug("Appended\n" + Uint8ArrayToHexDump(&addition[0], addition.size()));
 	response.insert(response.end(), addition.begin(), addition.end());
+	SendResponse(true);
+	//Betrock::Logger::Instance().Debug("After appending\n" + Uint8ArrayToHexDump(&response[0], response.size()));
 }
 
 // Send the contents of response to the Client
@@ -790,7 +793,7 @@ void Client::SendResponse(bool autoclear) {
 	if (debugReceivedBytes) {
 		debugMessage += "\n" + Uint8ArrayToHexDump(&response[0],response.size());
 	}
-	if (debugSentPacketType || debugSentBytes) {
+	if (debugReceivedPacketType || debugReceivedBytes) {
 		Betrock::Logger::Instance().Debug(debugMessage);
 	}
 	

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -4,11 +4,7 @@
 
 #include <ranges>
 
-Client::Client(Player* player) {
-	this->player = player;	
-}
-
-bool Client::CheckPosition(Player* player, Vec3 &newPosition, double &newStance) {
+bool Client::CheckPosition(Vec3 &newPosition, double &newStance) {
 	player->previousPosition = player->position;
 
 	player->position = newPosition;
@@ -25,7 +21,7 @@ ssize_t Client::Setup() {
 	previousOffset = 0;
 
 	// Read Data
-	return read(player->client_fd, message, PACKET_MAX);
+	return read(GetClientFd(), message, PACKET_MAX);
 }
 
 void Client::PrintReceived(Packet packetType, ssize_t bytes_received) {
@@ -55,8 +51,8 @@ void Client::PrintRead(Packet packetType) {
 	previousOffset = offset;
 }
 
-bool CheckIfNewChunksRequired(Player* player) {
-	Vec3 lastPos = player->lastChunkUpdatePosition;
+bool Client::CheckIfNewChunksRequired() {
+	Vec3 lastPos = lastChunkUpdatePosition;
 	Vec3 newPos = player->position;
 	// Remove vertical component
 	lastPos.y = 0;
@@ -67,32 +63,32 @@ bool CheckIfNewChunksRequired(Player* player) {
 	return false;
 }
 
-void ProcessChunk(std::vector<uint8_t>& response, const Int3& position, WorldManager* wm, Player* player) {
+void Client::ProcessChunk(const Int3& position, WorldManager* wm) {
 	// TODO: This is awful to do for every chunk :(
     // Skip processing if chunk is already visible
-    if (std::find(player->visibleChunks.begin(), player->visibleChunks.end(), position) != player->visibleChunks.end()) {
+    if (std::find(visibleChunks.begin(), visibleChunks.end(), position) != visibleChunks.end()) {
         return;
     }
 
     // Check if the chunk has already been loaded
     if (!wm->world.ChunkExists(position.x,position.z)) {
 		// Otherwise queue chunk loading or generation
-		wm->AddChunkToQueue(position.x, position.z, player);
+		wm->AddChunkToQueue(position.x, position.z, this);
 		Respond::PreChunk(response, position.x, position.z, 1); // Tell client chunk is being worked on
         return;
     }
     // If the chunk is already available, send it over
-    player->newChunks.push_back(position);
+    newChunks.push_back(position);
 }
 
-void SendChunksAroundPlayer(std::vector<uint8_t> &response, Player* player, bool forcePlayerAsCenter) {
+void Client::SendChunksAroundPlayer(bool forcePlayerAsCenter) {
     auto &server = Betrock::Server::Instance();
 
     Int3 centerPos;
 	if (forcePlayerAsCenter) {
 		centerPos = Vec3ToInt3(player->position);
 	} else {
-    	Vec3 delta = player->position - player->lastChunkUpdatePosition;
+    	Vec3 delta = player->position - lastChunkUpdatePosition;
 		centerPos = Vec3ToInt3(player->position+delta);
 	}
     Int3 playerChunkPos = BlockToChunkPosition(centerPos);
@@ -102,19 +98,19 @@ void SendChunksAroundPlayer(std::vector<uint8_t> &response, Player* player, bool
     auto chunkDistance = server.GetChunkDistance();
 
     // Remove chunks that are out of range
-    for (auto it = player->visibleChunks.begin(); it != player->visibleChunks.end(); ) {
+    for (auto it = visibleChunks.begin(); it != visibleChunks.end(); ) {
         int distanceX = abs(pX - it->x);
         int distanceZ = abs(pZ - it->z);
         if (distanceX > chunkDistance || distanceZ > chunkDistance) {
             Respond::PreChunk(response, it->x, it->z, 0); // Tell client chunk is no longer visible
-            it = player->visibleChunks.erase(it);
+            it = visibleChunks.erase(it);
 			//std::cout << "Deleted " << it->x << ", " << it->z << std::endl;
         } else {
             ++it;
         }
     }
 
-    auto wm = server.GetWorldManager(player->worldId);
+    auto wm = server.GetWorldManager(player->dimension);
 
 	// Iterate over all chunks within a bounding box defined by chunkDistance
 	for (int r = 0; r < chunkDistance; r++) {
@@ -122,33 +118,33 @@ void SendChunksAroundPlayer(std::vector<uint8_t> &response, Player* player, bool
 		for (int x = -r; x <= r; x++) {
 			for (int z : {-r, r}) {
 				Int3 position = XyzToInt3(x+pX, 0, z+pZ);
-				ProcessChunk(response, position, wm, player);
+				ProcessChunk(position, wm);
 			}
 		}
 		// Left and Right columns (excluding corners to avoid duplicates)
 		for (int z = -r + 1; z <= r - 1; z++) {
 			for (int x : {-r, r}) {
 				Int3 position = XyzToInt3(x+pX, 0, z+pZ);
-				ProcessChunk(response, position, wm, player);
+				ProcessChunk(position, wm);
 			}
 		}
 	}
 
-    player->lastChunkUpdatePosition = player->position;
+    lastChunkUpdatePosition = player->position;
 }
 
 void Client::SendNewChunks() {
 	// Send chunks in batches of 5
 	int sentThisCycle = 5;
-	auto wm = Betrock::Server::Instance().GetWorldManager(player->worldId);
-  	std::lock_guard<std::mutex> lock(player->newChunksMutex);
+	auto wm = Betrock::Server::Instance().GetWorldManager(player->dimension);
+  	std::lock_guard<std::mutex> lock(newChunksMutex);
 	while(sentThisCycle > 0) {
-		if(!player->newChunks.empty()) {
-			auto nc = player->newChunks.begin();
+		if(!newChunks.empty()) {
+			auto nc = newChunks.begin();
 			auto chunkData = wm->world.GetChunkData(*nc);
 			if (!chunkData) {
 				// We'll just drop this chunk
-				player->newChunks.erase(nc);
+				newChunks.erase(nc);
 				return;
 			}
 
@@ -159,7 +155,7 @@ void Client::SendNewChunks() {
 			if (chunk) {
 				//std::cout << "Sent " << nc->x << ", " << nc->z << std::endl;
 				Respond::PreChunk(response, nc->x, nc->z, 1);
-				player->visibleChunks.push_back(Int3{nc->x,0,nc->z});
+				visibleChunks.push_back(Int3{nc->x,0,nc->z});
 
 				Respond::Chunk(
 					response, 
@@ -173,29 +169,23 @@ void Client::SendNewChunks() {
 			}
 			// Better to remove the entry either way if compression fails,
 			// otherwise we may get an infinite build-up of failing chunks
-			player->newChunks.erase(nc);
+			newChunks.erase(nc);
 		}
 		sentThisCycle--;
 	}
 }
 
-void Client::Respond() {
-	SendToPlayer(response, player);
-	BroadcastToPlayers(broadcastResponse);
-	BroadcastToPlayers(broadcastOthersResponse, player);
-}
-
-void HandlePacket(Client &client) {
+void Client::HandlePacket() {
 	auto serverTime = Betrock::Server::Instance().GetServerTime();
 	int64_t lastPacketTime = serverTime;
 	bool validPacket = true;
 	// Prep for next packet
-	ssize_t bytes_received = client.Setup();
+	ssize_t bytes_received = Setup();
 
 	// If we receive no Data from the player, such as when they 
 	if (bytes_received <= 0) {
 		perror("read");
-		client.DisconnectClient("No data.");
+		HandleDisconnect("No data.");
 		return;
 	}
 
@@ -205,82 +195,82 @@ void HandlePacket(Client &client) {
 	if (debugReceivedBundleDelimiter) {
 		Betrock::Logger::Instance().Debug("--- Start of Packet bundle ---");
 	}
-	while (validPacket && client.offset < bytes_received && client.player->connectionStatus > ConnectionStatus::Disconnected) {
-		int8_t packetIndex = EntryToByte(client.message,client.offset);
+	while (validPacket && offset < bytes_received && GetConnectionStatus() > ConnectionStatus::Disconnected) {
+		int8_t packetIndex = EntryToByte(message,offset);
 		Packet packetType = (Packet)packetIndex;
 
 		// Provide debug info
 		if (debugReceivedBytes || debugReceivedPacketType) {
-			client.PrintReceived(packetType,bytes_received);
+			PrintReceived(packetType,bytes_received);
 		}
 
 		// Get the current Dimension
-		World* world = Betrock::Server::Instance().GetWorld(client.player->worldId);
+		World* world = Betrock::Server::Instance().GetWorld(player->dimension);
 		
 		// The Client tries to join the Server
 		switch(packetType) {
 			case Packet::KeepAlive:
-				client.KeepAlive();
+				HandleKeepAlive();
 				break;
 			case Packet::LoginRequest:
-				client.LoginRequest();
+				HandleLoginRequest();
 				break;
 			case Packet::Handshake:
-				client.Handshake();
+				HandleHandshake();
 				break;
 			case Packet::ChatMessage:
-				client.ChatMessage();
+				HandleChatMessage();
 				break;
 			case Packet::UseEntity:
-				client.UseEntity();
+				HandleUseEntity();
 				break;
 			case Packet::Respawn:
-				client.Respawn();
+				HandleRespawn();
 				break;
 			case Packet::Player:
-				client.PlayerGrounded();
+				HandlePlayerGrounded();
 				break;
 			case Packet::PlayerPosition:
-				client.PlayerPosition();
+				HandlePlayerPosition();
 				break;
 			case Packet::PlayerLook:
-				client.PlayerLook();
+				HandlePlayerLook();
 				break;
 			case Packet::PlayerPositionLook:
-				client.PlayerPositionLook();
+				HandlePlayerPositionLook();
 				break;
 			case Packet::HoldingChange:
-				client.HoldingChange();
+				HandleHoldingChange();
 				break;
 			case Packet::Animation:
-				client.Animation();
+				HandleAnimation();
 				break;
 			case Packet::EntityAction:
-				client.EntityAction();
+				HandleEntityAction();
 				break;
 			case Packet::PlayerDigging:
-				client.PlayerDigging(world);
+				HandlePlayerDigging(world);
 				break;
 			case Packet::PlayerBlockPlacement:
-				client.PlayerBlockPlacement(world);
+				HandlePlayerBlockPlacement(world);
 				break;
 			case Packet::CloseWindow:
-				client.CloseWindow();
+				HandleCloseWindow();
 				break;
 			case Packet::WindowClick:
-				client.WindowClick();
+				HandleWindowClick();
 				break;
 			case Packet::Disconnect:
-				client.DisconnectClient();
+				HandleDisconnect();
 				break;
 			default:
-				Betrock::Logger::Instance().Debug("Unhandled Server-bound packet: " + std::to_string(packetIndex) + "\n" + Uint8ArrayToHexDump(client.message,bytes_received));
+				Betrock::Logger::Instance().Debug("Unhandled Server-bound packet: " + std::to_string(packetIndex) + "\n" + Uint8ArrayToHexDump(message,bytes_received));
 				validPacket = false;
 				break;
 		}
-		if (client.player != nullptr && client.player->connectionStatus == ConnectionStatus::Connected) {
+		if (player != nullptr && GetConnectionStatus() == ConnectionStatus::Connected) {
 			if (debugPlayerStatus) {
-				client.player->PrintStats();
+				player->PrintStats();
 			}
 			// TODO: Fix this from killing the player during lag
 			// Kill player if he goes below 0,0
@@ -291,64 +281,76 @@ void HandlePacket(Client &client) {
 			*/
 		}
 		if (debugReceivedRead) {
-			client.PrintRead(packetType);
+			PrintRead(packetType);
 		}
 	}
-	client.SendNewChunks();
-	client.Respond();
+	SendNewChunks();
+
+	SendResponse();
+	//BroadcastToPlayers(broadcastResponse);
+	//BroadcastToPlayers(broadcastOthersResponse, player);
+	
 	if (debugNumberOfPacketBytes) {
-		Betrock::Logger::Instance().Debug("--- " + std::to_string(client.offset) + "/" + std::to_string(bytes_received) + " Bytes Read from Packet ---"); 
+		Betrock::Logger::Instance().Debug("--- " + std::to_string(offset) + "/" + std::to_string(bytes_received) + " Bytes Read from Packet ---"); 
 	}
 }
 
-// Give each Player their own thread
-void HandleClient(Player* player) {
-  auto &server = Betrock::Server::Instance();
+// Give each Client their own thread
+void Client::HandleClient() {
+  	auto &server = Betrock::Server::Instance();
+	player = std::make_shared<Player>(clientFd,
+		server.GetLatestEntityId(),
+		server.GetSpawnPoint(),
+		server.GetSpawnDimension(),
+		server.GetSpawnWorld(),
+		server.GetSpawnPoint(),
+		server.GetSpawnDimension(),
+		server.GetSpawnWorld()
+	);
 	// Assign player
-	Client client = Client(player);
+	//Client client = Client(player);
 
 	// While the player is connected, read packets from them
-	while (player->connectionStatus > ConnectionStatus::Disconnected) {
-		HandlePacket(client);
+	while (GetConnectionStatus() > ConnectionStatus::Disconnected) {
+		HandlePacket();
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000/TICK_SPEED)); // Sleep for half a second
 	}
-	std::lock_guard<std::mutex> lock(server.GetConnectedPlayerMutex());
+	std::lock_guard<std::mutex> lock(server.GetConnectedClientMutex());
 	player->Save();
-    int clientFdToDisconnect = player->client_fd;
 
-    auto &connectedPlayers = server.GetConnectedPlayers();
-    std::erase(connectedPlayers, player);
+    auto &connectedClients = server.GetConnectedClients();
+    std::erase(connectedClients, player);
 
-	close(clientFdToDisconnect);
+	close(GetClientFd());
 
-	delete player;
+	//delete player;
 
 	return;
 }
 
 // --- Packet answers ---
 
-bool Client::KeepAlive() {
+bool Client::HandleKeepAlive() {
 	Respond::KeepAlive(response);
 	return true;
 }
 
-bool Client::Handshake() {
-	if (player->connectionStatus != ConnectionStatus::Handshake) {
-		DisconnectClient("Expected Handshake.");
+bool Client::HandleHandshake() {
+	if (GetConnectionStatus() != ConnectionStatus::Handshake) {
+		HandleDisconnect("Expected Handshake.");
 		return false;
 	}
 	player->username = EntryToString16(message, offset);
 	Respond::Handshake(response);
-	player->connectionStatus = ConnectionStatus::LoggingIn;
+	SetConnectionStatus(ConnectionStatus::LoggingIn);
 	return true;
 }
 
-bool Client::LoginRequest() {
+bool Client::HandleLoginRequest() {
 	bool firstJoin = true;
 	auto &server = Betrock::Server::Instance();
-	if (player->connectionStatus != ConnectionStatus::LoggingIn) {
-		DisconnectClient("Expected Login.");
+	if (GetConnectionStatus() != ConnectionStatus::LoggingIn) {
+		HandleDisconnect("Expected Login.");
 		return false;
 	}
 
@@ -360,12 +362,12 @@ bool Client::LoginRequest() {
 
 	if (protocolVersion != PROTOCOL_VERSION) {
 		// If client has wrong protocol, close
-		DisconnectClient("Wrong Protocol Version!");
+		HandleDisconnect("Wrong Protocol Version!");
 		return false;
 	}
 
 	if (username != player->username) {
-		DisconnectClient("Client has mismatched username.");
+		HandleDisconnect("Client has mismatched username.");
 		return false;
 	} 
 
@@ -394,21 +396,21 @@ bool Client::LoginRequest() {
 		player->position = spawnPoint;
 
 		// Give starter items
-		player->Give(response,ITEM_PICKAXE_DIAMOND);
-		player->Give(response,ITEM_AXE_DIAMOND);
-		player->Give(response,ITEM_SHOVEL_DIAMOND);
-		player->Give(response,BLOCK_STONE);
-		player->Give(response,BLOCK_COBBLESTONE);
-		player->Give(response,BLOCK_PLANKS);
+		Give(response,ITEM_PICKAXE_DIAMOND);
+		Give(response,ITEM_AXE_DIAMOND);
+		Give(response,ITEM_SHOVEL_DIAMOND);
+		Give(response,BLOCK_STONE);
+		Give(response,BLOCK_COBBLESTONE);
+		Give(response,BLOCK_PLANKS);
 	} else {
-		player->UpdateInventory(response);
+		UpdateInventory(response);
 	}
 
 	// TODO: This hack seems stupid
 	player->position.y += 0.1;
 	// Note: Teleporting automatically loads surrounding chunks,
 	// so no further loading is necessary
-	player->Teleport(response,player->position, player->yaw, player->pitch);
+	Teleport(response,player->position, player->yaw, player->pitch);
 
 	// Create the player for other players
 	Respond::NamedEntitySpawn(
@@ -429,6 +431,7 @@ bool Client::LoginRequest() {
 	);
 
 	// Spawn the other players for the new client
+	/*
     for (Player* others : Betrock::Server::Instance().GetConnectedPlayers()) {
 		if (others == player) { continue; }
 		Respond::NamedEntitySpawn(
@@ -450,19 +453,19 @@ bool Client::LoginRequest() {
 			ConvertFloatToPackedByte(others->pitch)
 		);
 
-    }
+    }*/
 	Respond::ChatMessage(response, std::string("This Server runs on ") + std::string(PROJECT_NAME_VERSION));
-	SendToPlayer(response,player);
+	SendResponse();
 	// ONLY SET THIS AFTER LOGIN HAS FINISHED
-	player->connectionStatus = ConnectionStatus::Connected;
+	SetConnectionStatus(ConnectionStatus::Connected);
 	return true;
 }
 
-bool Client::ChatMessage() {
+bool Client::HandleChatMessage() {
 	std::string chatMessage = EntryToString16(message, offset);
 	if (chatMessage.size() > 0 && chatMessage[0] == '/') {
 		std::string command = chatMessage.substr(1);
-		Command::Parse(command, player);
+		Command::Parse(command, this);
 	} else {
 		std::string sentChatMessage = "<" + player->username + "> " + chatMessage;
 		Betrock::Logger::Instance().Info(sentChatMessage);
@@ -471,20 +474,20 @@ bool Client::ChatMessage() {
 	return true;
 }
 
-bool Client::UseEntity() {
+bool Client::HandleUseEntity() {
 	int32_t originEntityId = EntryToInteger(message, offset);
 	int32_t recipientEntityId = EntryToInteger(message, offset);
 	bool leftClick = EntryToByte(message, offset);
 	return true;
 }
 
-bool Client::Respawn() {
+bool Client::HandleRespawn() {
 	int8_t dimension = EntryToByte(message, offset);
-	player->Respawn(response);
+	Respawn(response);
 	return true;
 }
 
-bool Client::PlayerGrounded() {
+bool Client::HandlePlayerGrounded() {
 	player->onGround = EntryToByte(message, offset);
 	return true;
 }
@@ -497,7 +500,7 @@ bool Client::UpdatePositionForOthers(bool includeLook) {
 		ConvertFloatToPackedByte(player->yaw),
 		ConvertFloatToPackedByte(player->pitch)
 	);
-	player->lastTickPosition = player->position;
+	player->previousPosition = player->position;
 	/*
 	if (GetDistance(player->position,player->lastTickPosition) > 4.0) {
 		Respond::EntityTeleport(
@@ -528,7 +531,7 @@ bool Client::UpdatePositionForOthers(bool includeLook) {
 	return true;
 }
 
-bool Client::PlayerPosition() {
+bool Client::HandlePlayerPosition() {
 	Vec3 newPosition;
 	double newStance;
 	newPosition.x = EntryToDouble(message,offset);
@@ -536,16 +539,16 @@ bool Client::PlayerPosition() {
 	newStance = EntryToDouble(message,offset);
 	newPosition.z = EntryToDouble(message,offset);
 	player->onGround = EntryToByte(message, offset);
-	CheckPosition(player,newPosition,newStance);
+	CheckPosition(newPosition,newStance);
 	UpdatePositionForOthers(false);
 
-	if (CheckIfNewChunksRequired(player)) {
-		SendChunksAroundPlayer(response,player);
+	if (CheckIfNewChunksRequired()) {
+		SendChunksAroundPlayer();
 	}
 	return true;
 }
 
-bool Client::PlayerLook() {
+bool Client::HandlePlayerLook() {
 	player->yaw = EntryToFloat(message,offset);
 	player->pitch = EntryToFloat(message,offset);
 	player->onGround = EntryToByte(message, offset);
@@ -553,7 +556,7 @@ bool Client::PlayerLook() {
 	return true;
 }
 
-bool Client::PlayerPositionLook() {
+bool Client::HandlePlayerPositionLook() {
 	Vec3 newPosition;
 	double newStance;
 	newPosition.x = EntryToDouble(message,offset);
@@ -563,23 +566,23 @@ bool Client::PlayerPositionLook() {
 	player->yaw   = EntryToFloat(message,offset);
 	player->pitch = EntryToFloat(message,offset);
 	player->onGround = EntryToByte(message, offset);
-	CheckPosition(player,newPosition,newStance);
+	CheckPosition(newPosition,newStance);
 
 	UpdatePositionForOthers(true);
 
-	if (CheckIfNewChunksRequired(player)) {
-		SendChunksAroundPlayer(response,player);
+	if (CheckIfNewChunksRequired()) {
+		SendChunksAroundPlayer();
 	}
 	return true;
 }
 
-bool Client::HoldingChange() {
+bool Client::HandleHoldingChange() {
 	int16_t slot = EntryToShort(message, offset);
-	player->ChangeHeldItem(broadcastOthersResponse,slot);
+	ChangeHeldItem(broadcastOthersResponse,slot);
 	return true;
 }
 
-bool Client::Animation() {
+bool Client::HandleAnimation() {
 	int32_t entityId = EntryToInteger(message, offset);
 	int8_t animation = EntryToByte(message, offset);
 	// Only send this to other clients
@@ -587,7 +590,7 @@ bool Client::Animation() {
 	return true;
 }
 
-bool Client::EntityAction() {
+bool Client::HandleEntityAction() {
 	int32_t entityId = EntryToInteger(message, offset);
 	int8_t action = EntryToByte(message, offset);
 	// some EntityMetadata info
@@ -611,7 +614,7 @@ bool Client::EntityAction() {
 	return true;
 }
 
-bool Client::PlayerDigging(World* world) {
+bool Client::HandlePlayerDigging(World* world) {
 	int8_t status = EntryToByte(message, offset);
 	int32_t x = EntryToInteger(message, offset);
 	int8_t y = EntryToByte(message, offset);
@@ -643,7 +646,7 @@ bool Client::PlayerDigging(World* world) {
 			if (!player->creativeMode) {
 				item = GetDrop(item);
 			}
-			player->Give(response,item.id,item.amount,item.damage);
+			Give(response,item.id,item.amount,item.damage);
 		}
 	}
 	return true;
@@ -682,7 +685,7 @@ bool Client::BlockTooCloseToPosition(Int3 position) {
     return overlapX && overlapY && overlapZ;
 }
 
-bool Client::PlayerBlockPlacement(World* world) {
+bool Client::HandlePlayerBlockPlacement(World* world) {
 	int32_t x = EntryToInteger(message, offset);
 	int8_t y = EntryToByte(message, offset);
 	int32_t z = EntryToInteger(message, offset);
@@ -711,33 +714,33 @@ bool Client::PlayerBlockPlacement(World* world) {
 		damage = GetMetaData(x,y,z,direction,id,damage);
 	}
 	// Place a block if we can
-	if (id > BLOCK_AIR && id < BLOCK_MAX && !BlockTooCloseToPosition(pos) && player->CanDecrementHotbar()) {
+	if (id > BLOCK_AIR && id < BLOCK_MAX && !BlockTooCloseToPosition(pos) && CanDecrementHotbar()) {
 		//std::cout << BlockTooCloseToPosition(pos) << ": " << pos << " - " << player->position << std::endl;
-		Item i = player->inventory[INVENTORY_HOTBAR+player->currentHotbarSlot];
+		Item i = player->inventory[INVENTORY_HOTBAR+currentHotbarSlot];
 		// TODO: Make sure damage value is valid(?)
 		//damage = CheckIfValidDamage();
 		Respond::BlockChange(broadcastResponse,pos,(int8_t)i.id,(int8_t)damage);
 		world->PlaceBlock(pos,(int8_t)i.id,(int8_t)damage);
 		// Immediately give back item if we're in creative mode
 		if (player->creativeMode) {
-			Item i = player->GetHeldItem();
+			Item i = GetHeldItem();
 			id = i.id;
 			amount = i.amount;
-			Respond::SetSlot(response,0,player->GetHotbarSlot(),id,amount,i.damage);
+			Respond::SetSlot(response,0,GetHotbarSlot(),id,amount,i.damage);
 		} else {
-			player->DecrementHotbar(response);
+			DecrementHotbar(response);
 		}
 	}
 	return true;
 }
 
-bool Client::CloseWindow() {
+bool Client::HandleCloseWindow() {
 	int8_t window 	= EntryToByte(message, offset);
 	activeWindow = INVENTORY_NONE;
 	return true;
 }
 
-bool Client::WindowClick() {
+bool Client::HandleWindowClick() {
 	int8_t window 		= EntryToByte(message, offset);
 	int16_t slot 		= EntryToShort(message,offset);
 	int8_t rightClick 	= EntryToByte(message, offset);
@@ -750,18 +753,226 @@ bool Client::WindowClick() {
 		itemCount		= EntryToByte(message, offset);
 		itemUses		= EntryToShort(message,offset);
 	}
-	player->ClickedSlot(response,window,slot,(bool)rightClick,actionNumber,shift,itemId,itemCount,itemUses);
+	ClickedSlot(response,window,slot,(bool)rightClick,actionNumber,shift,itemId,itemCount,itemUses);
 	return true;
 }
 
 // This should be used for disconnecting clients
-bool Client::DisconnectClient(std::string disconnectMessage) {
+bool Client::HandleDisconnect(std::string disconnectMessage) {
 	if (disconnectMessage == "") {
 		disconnectMessage = EntryToString16(message, offset);
 	}
-	Disconnect(player,disconnectMessage);
+
+	SetConnectionStatus(ConnectionStatus::Disconnected);
+	Respond::Disconnect(response, disconnectMessage);
+	SendResponse();
+	Betrock::Logger::Instance().Info(player->username + " has disconnected. (" + disconnectMessage + ")");
+
 	Respond::DestroyEntity(broadcastResponse,player->entityId);
 	Respond::ChatMessage(broadcastResponse, "§e" + player->username + " left the game.");
 	Respond();
 	return true;
+}
+
+void Client::AppendResponse(std::vector<uint8_t> &addition) {
+	response.insert(response.end(), addition.begin(), addition.end());
+}
+
+// Send the contents of response to the Client
+void Client::SendResponse(bool autoclear) {
+	if (response.empty() || GetConnectionStatus() <= ConnectionStatus::Disconnected) {
+		return;
+	}
+
+	if (debugSentPacketType) {
+		Betrock::Logger::Instance().Debug("Sending " + PacketIdToLabel((Packet)response[0]) + " to " + player->username + "(" + std::to_string(player->entityId) + ") ! (" + std::to_string(response.size()) + " Bytes)");
+	}
+		
+	if (debugSentBytes) {
+		for (uint i = 0; i < response.size(); i++) {
+			std::cout << std::hex << (int)response[i];
+			if (i < response.size()-1) {
+				std::cout << ", ";
+			}
+		}
+		std::cout << std::dec << std::endl;
+	}
+	
+	ssize_t bytes_sent = send(GetClientFd(), response.data(), response.size(), 0);
+	if (bytes_sent == -1) {
+		perror("send");
+		return;
+	}
+	if (autoclear) {
+		response.clear();
+	}
+}
+
+void Client::Teleport(std::vector<uint8_t> &response, Vec3 position, float yaw, float pitch) {
+    player->position = position;
+    player->yaw = yaw;
+    player->pitch = pitch;
+    player->stance = player->position.y + STANCE_OFFSET;
+    //this->newChunks.clear();
+    Respond::PlayerPositionLook(response, player.get());
+    //SendChunksAroundPlayer(response,this, true);
+}
+
+void Client::Respawn(std::vector<uint8_t> &response) {
+    player->dimension = player->spawnDimension;
+    player->world = player->spawnWorld;
+    Teleport(response, player->spawnPosition);
+    Respond::Respawn(response, player->dimension);
+    // After respawning, the health is automatically set back to the maximum health
+    // The Client should do this automatically
+    player->health = HEALTH_MAX;
+}
+
+
+bool Client::TryToPutInSlot(int16_t slot, int16_t &id, int8_t &amount, int16_t &damage) {
+    // First, try to stack into existing slots
+    if (player->inventory[slot].id == id && player->inventory[slot].damage == damage) {
+        // Skip the slot if its full
+        if (player->inventory[slot].amount >= MAX_STACK) {
+            return false;
+        }
+        // If we fill the slot, we're done
+        if (player->inventory[slot].amount + amount <= MAX_STACK) {
+            player->inventory[slot].amount += amount;
+            return true;
+        }
+        // If we fill it but items remain, keep going
+        amount -= (MAX_STACK - player->inventory[slot].amount);
+        player->inventory[slot].amount = MAX_STACK;
+        return false;
+    }
+    // Secondly, try to stack into empty slots
+    if (player->inventory[slot].id == SLOT_EMPTY) {
+        player->inventory[slot] = { id, amount, damage };
+        return true;
+    }
+    return false;
+}
+
+bool Client::SpreadToSlots(int16_t id, int8_t amount, int16_t damage, int8_t preferredRange) {
+    if (preferredRange == 1 || preferredRange == 0) {
+        for (int8_t i = INVENTORY_HOTBAR; i <= INVENTORY_HOTBAR_LAST; i++) {
+            if (TryToPutInSlot(i, id, amount, damage)) {
+                return true;
+            }
+        }
+    }
+
+    if (preferredRange == 2 || preferredRange == 0) {
+        for (int8_t i = INVENTORY_ROW_1; i <= INVENTORY_ROW_LAST; i++) {
+            if (TryToPutInSlot(i, id, amount, damage)) {
+                return true;
+            }
+        }
+    }
+
+    // If there are still items left, inventory is full
+    return false;
+}
+
+bool Client::Give(std::vector<uint8_t> &response, int16_t item, int8_t amount, int16_t damage) {
+    // Amount is not specified
+    if (amount == -1) {
+        if (item < BLOCK_MAX) {
+            amount = MAX_STACK;
+        } else {
+            amount = 1;
+        }
+    }
+    // Look for empty slot
+    SpreadToSlots(item,amount,damage);
+    //inventory[slotId] = Item { item,amount,damage };
+    // TODO: This is a horrible solution, please find something better,
+    // like checking if the inventory was changed, and only then sending out an UpdateInventory
+    UpdateInventory(response);
+    return true;
+}
+
+bool Client::UpdateInventory(std::vector<uint8_t> &response) {
+    std::vector<Item> v(std::begin(player->inventory), std::end(player->inventory));
+    Respond::WindowItems(response, 0, v);
+    return true;
+}
+
+void Client::ChangeHeldItem(std::vector<uint8_t> &response, int16_t slotId) {
+	currentHotbarSlot = (int8_t)slotId;
+    Item i = GetHeldItem();
+    Respond::EntityEquipment(response, player->entityId, EQUIPMENT_SLOT_HELD, i.id, i.damage);
+}
+
+int16_t Client::GetHotbarSlot() {
+    return INVENTORY_HOTBAR + currentHotbarSlot;
+}
+
+Item Client::GetHeldItem() {
+    return player->inventory[GetHotbarSlot()];
+}
+
+// TODO: Implement Right-clicking
+void Client::ClickedSlot(std::vector<uint8_t> &response, int8_t windowId, int16_t slotId, bool rightClick, int16_t actionNumber, bool shift, int16_t id, int8_t amount, int16_t damage) {
+    // Shift Click Behavior
+    if (shift) {
+        // Get item
+        Item temp = player->inventory[slotId];
+        // Empty slot
+        player->inventory[slotId] = {-1,0,0};
+        if (slotId >= INVENTORY_HOTBAR) {
+            SpreadToSlots(temp.id,temp.amount,temp.damage,2);
+        } else {
+            SpreadToSlots(temp.id,temp.amount,temp.damage,1);
+        }
+    }
+    
+    // If we've clicked outside, throw the items to the ground and clear the slot.
+    if (slotId == CLICK_OUTSIDE) {
+        hoveringItem = Item {-1,0,0};
+        return;
+    }
+
+    // If something is being held
+    if (hoveringItem.id < BLOCK_STONE) {
+        Item temp = hoveringItem;
+        hoveringItem = player->inventory[slotId];
+        player->inventory[slotId] = temp;
+    } else {
+        Item temp = player->inventory[slotId];
+        player->inventory[slotId] = hoveringItem;
+        hoveringItem = temp;
+    }
+    lastClickedSlot = slotId;
+}
+
+void Client::ClearInventory() {
+    // Fill inventory with empty slots
+    for (int i = 0; i < INVENTORY_MAX_SLOTS; ++i) {
+        player->inventory[i] = Item{-1, 0, 0};
+    }
+}
+
+bool Client::CanDecrementHotbar() {
+    Item i = GetHeldItem();
+    if (i.id > BLOCK_AIR && i.amount > 0) {
+        return true;
+    }
+    return false;
+}
+
+void Client::DecrementHotbar(std::vector<uint8_t> &response) {
+    Item* i = &player->inventory[GetHotbarSlot()];
+    i->amount--;
+    if (i->amount <= 0) {
+        i->id = -1;
+        i->amount = 0;
+        i->damage = 0;
+    }
+	Respond::SetSlot(response, 0, GetHotbarSlot(), i->id, i->amount, i->damage);
+}
+
+bool Client::ChunkIsVisible(Int3 pos) {
+	return std::find(visibleChunks.begin(), visibleChunks.end(), pos) != visibleChunks.end();
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -287,8 +287,8 @@ void Client::HandlePacket() {
 	SendNewChunks();
 
 	SendResponse();
-	//BroadcastToPlayers(broadcastResponse);
-	//BroadcastToPlayers(broadcastOthersResponse, player);
+	BroadcastToClients(broadcastResponse);
+	BroadcastToClients(broadcastOthersResponse, this);
 	
 	if (debugNumberOfPacketBytes) {
 		Betrock::Logger::Instance().Debug("--- " + std::to_string(offset) + "/" + std::to_string(bytes_received) + " Bytes Read from Packet ---"); 
@@ -298,7 +298,7 @@ void Client::HandlePacket() {
 // Give each Client their own thread
 void Client::HandleClient() {
   	auto &server = Betrock::Server::Instance();
-	player = std::make_shared<Player>(clientFd,
+	player = std::make_unique<Player>(
 		server.GetLatestEntityId(),
 		server.GetSpawnPoint(),
 		server.GetSpawnDimension(),
@@ -307,6 +307,7 @@ void Client::HandleClient() {
 		server.GetSpawnDimension(),
 		server.GetSpawnWorld()
 	);
+	ClearInventory();
 	// Assign player
 	//Client client = Client(player);
 
@@ -319,7 +320,7 @@ void Client::HandleClient() {
 	player->Save();
 
     auto &connectedClients = server.GetConnectedClients();
-    std::erase(connectedClients, player);
+    //std::erase(connectedClients, player);
 
 	close(GetClientFd());
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -809,9 +809,9 @@ void Client::Teleport(std::vector<uint8_t> &response, Vec3 position, float yaw, 
     player->yaw = yaw;
     player->pitch = pitch;
     player->stance = player->position.y + STANCE_OFFSET;
-    //this->newChunks.clear();
+    newChunks.clear();
     Respond::PlayerPositionLook(response, player.get());
-    //SendChunksAroundPlayer(response,this, true);
+    SendChunksAroundPlayer(true);
 }
 
 void Client::Respawn(std::vector<uint8_t> &response) {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -306,25 +306,17 @@ void Client::HandleClient() {
 		server.GetSpawnWorld()
 	);
 	ClearInventory();
-	// Assign player
-	//Client client = Client(player);
 
 	// While the player is connected, read packets from them
 	while (GetConnectionStatus() > ConnectionStatus::Disconnected) {
+		std::cout << "Packet" << std::endl;
 		HandlePacket();
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000/TICK_SPEED)); // Sleep for half a second
 	}
-	std::lock_guard<std::mutex> lock(server.GetConnectedClientMutex());
+
 	player->Save();
-
-    auto &connectedClients = server.GetConnectedClients();
-    //std::erase(connectedClients, player);
-
-	close(GetClientFd());
-
-	//delete player;
-
-	return;
+	thread.join();
+	delete this;
 }
 
 // --- Packet answers ---

--- a/src/client.h
+++ b/src/client.h
@@ -31,7 +31,7 @@ enum class ConnectionStatus {
     Connected
 };
 
-class Client {
+class Client : public std::enable_shared_from_this<Client> {
     private:
         std::unique_ptr<Player> player;
         int32_t previousOffset = 0;
@@ -46,7 +46,6 @@ class Client {
         int64_t lastPacketTime = 0;
         int clientFd;
         std::atomic<ConnectionStatus> connectionStatus = ConnectionStatus::Disconnected;
-        std::jthread thread;
         
         std::vector<Int3> visibleChunks;
         std::vector<Int3> newChunks;
@@ -103,8 +102,7 @@ class Client {
         void SetClientFd(int clientFd) { this->clientFd = clientFd; }
         int GetClientFd() { return this->clientFd; }
 
-        Client(int clientFd) : clientFd(clientFd), thread(&Client::HandleClient, this) {}
-        ~Client() { close(GetClientFd()); std::cout << "Client died!" << std::endl; };
+        Client(int clientFd) : clientFd(clientFd) {}
         void HandleClient();
         bool HandleDisconnect(std::string disconnectMessage = "");
 

--- a/src/client.h
+++ b/src/client.h
@@ -5,8 +5,8 @@
 #include <cstdint>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <mutex>
 
-#include "coms.h"
 #include "player.h"
 #include "command.h"
 #include "worldManager.h"
@@ -21,52 +21,104 @@
 
 #define PACKET_MAX 4096
 
+class WorldManager;
+
+enum class ConnectionStatus {
+    Disconnected,
+    Handshake,
+    LoggingIn,
+    Connected
+};
+
 class Client {
-    public:
-        Client(Player* player);
-        Player* player;
+    private:
+        std::shared_ptr<Player> player;
         int32_t previousOffset = 0;
         int32_t offset = 0;
         uint8_t message[PACKET_MAX] = {0};
 
-        int8_t activeWindow = INVENTORY_NONE;
-
         std::vector<uint8_t> response;
         std::vector<uint8_t> broadcastResponse;
         std::vector<uint8_t> broadcastOthersResponse;
+
+        int8_t activeWindow = INVENTORY_NONE;
+        int64_t lastPacketTime = 0;
+        int clientFd;
+        ConnectionStatus connectionStatus = ConnectionStatus::Disconnected;
+        
+        std::vector<Int3> visibleChunks;
+        std::vector<Int3> newChunks;
+        std::mutex newChunksMutex;  
+        Vec3 lastChunkUpdatePosition;
+
+        // Server-side inventory
+        int16_t lastClickedSlot = 0;
+        Item hoveringItem = Item {-1,0,0};
+        int8_t currentHotbarSlot = 0;
         
         ssize_t Setup();
         void PrintReceived(Packet packetType, ssize_t bytes_received);
         void PrintRead(Packet packetType);
 
-        bool KeepAlive();
-        bool Handshake();
-        bool LoginRequest();
-        bool ChatMessage();
-        bool UseEntity();
-        bool Respawn();
-        bool PlayerGrounded();
-        bool PlayerPosition();
-        bool PlayerLook();
-        bool PlayerPositionLook();
-        bool HoldingChange();
-        bool Animation();
-        bool EntityAction();
-        bool PlayerDigging(World* world);
-        bool PlayerBlockPlacement(World* world);
-        bool CloseWindow();
-        bool WindowClick();
-        bool DisconnectClient(std::string disconnectMessage = "");
+        // Packets
+        bool HandleKeepAlive();
+        bool HandleHandshake();
+        bool HandleLoginRequest();
+        bool HandleChatMessage();
+        bool HandleUseEntity();
+        bool HandleRespawn();
+        bool HandlePlayerGrounded();
+        bool HandlePlayerPosition();
+        bool HandlePlayerLook();
+        bool HandlePlayerPositionLook();
+        bool HandleHoldingChange();
+        bool HandleAnimation();
+        bool HandleEntityAction();
+        bool HandlePlayerDigging(World* world);
+        bool HandlePlayerBlockPlacement(World* world);
+        bool HandleCloseWindow();
+        bool HandleWindowClick();
 
-        void Respond();
+        // Helpers
+        void Respawn(std::vector<uint8_t> &response);
+
         void SendNewChunks();
         bool UpdatePositionForOthers(bool includeLook = true);
-
-    private:
-        bool CheckPosition(Player* player, Vec3 &newPosition, double &newStance); 
+        bool CheckPosition(Vec3 &newPosition, double &newStance); 
         bool BlockTooCloseToPosition(Int3 position);
-};
+        void HandlePacket();
+        void ProcessChunk(const Int3& position, WorldManager* wm);
+        void SendChunksAroundPlayer(bool forcePlayerAsCenter = false);
+        bool CheckIfNewChunksRequired();
+        bool TryToPutInSlot(int16_t slot, int16_t &id, int8_t &amount, int16_t &damage);
+        bool SpreadToSlots(int16_t item, int8_t amount, int16_t damage, int8_t preferredRange = 0);
+        void ClickedSlot(std::vector<uint8_t> &response, int8_t windowId, int16_t slotId, bool rightClick, int16_t actionNumber, bool shift, int16_t id, int8_t amount, int16_t damage);
+        void ChangeHeldItem(std::vector<uint8_t> &response, int16_t slotId);
+        void ClearInventory();
+    public:
+        void SetConnectionStatus(ConnectionStatus status) { this->connectionStatus = status; }
+        ConnectionStatus GetConnectionStatus() { return this->connectionStatus; }
+        void SetClientFd(int clientFd) { this->clientFd = clientFd; }
+        int GetClientFd() { return this->clientFd; }
 
-void HandleClient(Player* player);
-void ProcessChunk(std::vector<uint8_t>& response, const Int3& position, WorldManager* wm, Player* player);
-void SendChunksAroundPlayer(std::vector<uint8_t> &response, Player* player, bool forcePlayerAsCenter = false);
+        Client(int clientFd) : clientFd(clientFd){};
+        void HandleClient();
+        bool HandleDisconnect(std::string disconnectMessage = "");
+
+        bool Give(std::vector<uint8_t> &response, int16_t item, int8_t amount = -1, int16_t damage = 0);
+        bool UpdateInventory(std::vector<uint8_t> &response);
+        int16_t GetHotbarSlot();
+        Item GetHeldItem();
+        bool CanDecrementHotbar();
+        void DecrementHotbar(std::vector<uint8_t> &response);
+
+        Player* GetPlayer() { return this->player.get(); };
+        void Teleport(std::vector<uint8_t> &response, Vec3 position, float yaw = 0, float pitch = 0);
+        void AppendResponse(std::vector<uint8_t> &addition);
+        void SendResponse(bool autoclear = false);
+
+        bool ChunkIsVisible(Int3 pos);
+
+        std::mutex &GetNewChunksMutex() noexcept { return this->newChunksMutex; }
+        void AddNewChunk(Int3 pos) { newChunks.push_back(pos); }
+};

--- a/src/client.h
+++ b/src/client.h
@@ -32,7 +32,7 @@ enum class ConnectionStatus {
 
 class Client {
     private:
-        std::shared_ptr<Player> player;
+        std::unique_ptr<Player> player;
         int32_t previousOffset = 0;
         int32_t offset = 0;
         uint8_t message[PACKET_MAX] = {0};

--- a/src/coms/coms.cpp
+++ b/src/coms/coms.cpp
@@ -12,7 +12,7 @@ void BroadcastToClients(std::vector<uint8_t> &response, Client* sender, bool aut
 
 	std::scoped_lock lock(server.GetConnectedClientMutex());
     for (auto client : server.GetConnectedClients()) {
-		if (client == sender) { continue; }
+		if (client.get() == sender) { continue; }
 		if (client->GetConnectionStatus() == ConnectionStatus::Connected) {
 			client->AppendResponse(response);
 		}

--- a/src/coms/coms.h
+++ b/src/coms/coms.h
@@ -6,13 +6,13 @@
 #include <vector>
 #include <mutex>
 
-#include "player.h"
+#include "client.h"
 #include "debug.h"
 #include "responses.h"
 #include "world.h"
 #include "packets.h"
 
-void SendToPlayer(std::vector<uint8_t> &response, Player* player, bool autoclear = true);
-void BroadcastToPlayers(std::vector<uint8_t> &response, Player* sender = nullptr, bool autoclear = true);
-void Disconnect(Player* player, std::string message = "");
-void DisconnectAllPlayers(std::string message = "");
+class Client;
+
+void BroadcastToClients(std::vector<uint8_t> &response, Client* sender = nullptr, bool autoclear = true);
+void DisconnectAllClients(std::string message = "");

--- a/src/coms/responses.cpp
+++ b/src/coms/responses.cpp
@@ -264,7 +264,7 @@ void Respond::WindowItems(std::vector<uint8_t> &response, int8_t window, std::ve
     }
 }
 
-void Respond::Disconnect(std::vector<uint8_t> &response, Player* player, std::string message) {
+void Respond::Disconnect(std::vector<uint8_t> &response, std::string message) {
 	std::vector<uint8_t> disconnectResponse;
 	disconnectResponse.push_back((uint8_t)Packet::Disconnect);
 	AppendString16ToVector(disconnectResponse,message);

--- a/src/coms/responses.h
+++ b/src/coms/responses.h
@@ -44,5 +44,5 @@ class Respond {
         static void Soundeffect(std::vector<uint8_t> &response, int32_t sound, Int3 position, int32_t extra);
         static void SetSlot(std::vector<uint8_t> &response, int8_t window, int16_t slot, int16_t itemId, int8_t itemCount, int16_t itemUses);
         static void WindowItems(std::vector<uint8_t> &response, int8_t window, std::vector<Item> payload);
-        static void Disconnect(std::vector<uint8_t> &response, Player* player, std::string message);
+        static void Disconnect(std::vector<uint8_t> &response, std::string message);
 };

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,6 +1,6 @@
 #include "debug.h"
-bool debugReceivedBytes = true;
-bool debugReceivedPacketType = true;
+bool debugReceivedBytes = false;
+bool debugReceivedPacketType = false;
 
 bool debugReceivedBundleDelimiter = false;
 bool debugReceivedRead = false;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -5,8 +5,8 @@ bool debugReceivedPacketType = false;
 bool debugReceivedBundleDelimiter = false;
 bool debugReceivedRead = false;
 
-bool debugSentBytes = true;
-bool debugSentPacketType = true;
+bool debugSentBytes = false;
+bool debugSentPacketType = false;
 
 bool debugNumberOfPacketBytes = false;
 bool debugPlayerStatus = false;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,12 +1,12 @@
 #include "debug.h"
-bool debugReceivedBytes = false;
-bool debugReceivedPacketType = false;
+bool debugReceivedBytes = true;
+bool debugReceivedPacketType = true;
 
 bool debugReceivedBundleDelimiter = false;
 bool debugReceivedRead = false;
 
-bool debugSentBytes = false;
-bool debugSentPacketType = false;
+bool debugSentBytes = true;
+bool debugSentPacketType = true;
 
 bool debugNumberOfPacketBytes = false;
 bool debugPlayerStatus = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main() {
 			server.SetServerTime(server.GetServerTime() + 20);
 		}
 		Respond::Time(response, server.GetServerTime());
-		BroadcastToPlayers(response);
+		BroadcastToClients(response);
 		sleep(1); // Send data every second
 	}
 

--- a/src/misc/command.cpp
+++ b/src/misc/command.cpp
@@ -7,11 +7,11 @@ std::vector<uint8_t> response;
 std::vector<std::string> command;
 std::string failureReason;
 
-// Toggle the players pose bits
-void Command::Help(Player* player) {
+// Toggle the clients pose bits
+void Command::Help(Client* client) {
 }
 
-// Toggle the players pose bits
+// Toggle the clients pose bits
 void Command::Pose(Player* player) {	
 	// Set the time
 	if (command.size() > 1) {
@@ -29,13 +29,13 @@ void Command::Pose(Player* player) {
 		int8_t responseByte = (player->sitting << 2 | player->crouching << 1 | player->onFire);
 		Respond::ChatMessage(response, "§7Set Pose " + std::to_string((int)responseByte));
 		Respond::EntityMetadata(broadcastResponse, player->entityId, responseByte);
-		BroadcastToPlayers(broadcastResponse);
+		BroadcastToClients(broadcastResponse);
 		failureReason = "";
 		return;
 	}
 }
 
-// Play a sound at the players location
+// Play a sound at the clients location
 void Command::Sound(Player* player) {	
 	// Set the time
 	if (command.size() > 1) {
@@ -47,7 +47,7 @@ void Command::Sound(Player* player) {
 		std::vector<uint8_t> broadcastResponse;
 		Respond::Soundeffect(broadcastResponse,sound,Vec3ToInt3(player->position),extraData);
 		Respond::ChatMessage(response, "§7Playing Sound " + std::to_string(sound));
-		BroadcastToPlayers(broadcastResponse);
+		BroadcastToClients(broadcastResponse);
 		failureReason = "";
 		return;
 	}
@@ -73,14 +73,14 @@ void Command::Time() {
 	}
 }
 
-void Command::Teleport(Player* player) {
+void Command::Teleport(Client* client) {
 	std::vector<uint8_t> sourceResponse;
 	// Set the time
 	if (command.size() > 1) {
-		// Player that is to-be teleported
+		// client that is to-be teleported
 		std::string source = command[1];
-		auto sourcePlayer = Betrock::Server::Instance().FindPlayerByUsername(source);
-		if (!sourcePlayer) {
+		auto sourceClient = Betrock::Server::Instance().FindClientByUsername(source);
+		if (!sourceClient) {
 			failureReason = source + " does not exist! (Source)";
 			return;
 		}
@@ -91,8 +91,12 @@ void Command::Teleport(Player* player) {
 			int32_t y = std::stoi(command[3].c_str());
 			int32_t z = std::stoi(command[4].c_str());
 			Int3 tpGoal = {x,y,z};
-			sourcePlayer->Teleport(sourceResponse,Int3ToVec3(tpGoal));
-			SendToPlayer(sourceResponse, sourcePlayer);
+			sourceClient->Teleport(
+				sourceResponse,
+				Int3ToVec3(tpGoal)
+			);
+			sourceClient->AppendResponse(sourceResponse);
+			auto sourcePlayer = sourceClient->GetPlayer();
 			Respond::ChatMessage(response, "§7Teleported  " + sourcePlayer->username + " to (" + std::to_string(x) + ", "  + std::to_string(y) + ", " + std::to_string(z) + ")");
 			failureReason = "";
 			return;
@@ -100,16 +104,23 @@ void Command::Teleport(Player* player) {
 			// Fallthrough
 		}
 
-		// Option 2: Target player
+		// Option 2: Target client
 		try {
 			std::string destination = command[2];
-			auto destinationPlayer = Betrock::Server::Instance().FindPlayerByUsername(destination);
-			if (!destinationPlayer) {
+			auto destinationClient = Betrock::Server::Instance().FindClientByUsername(destination);
+			if (!destinationClient) {
 				failureReason = destination + " does not exist! (Destination)";
 				return;
 			}
-			sourcePlayer->Teleport(sourceResponse,destinationPlayer->position,destinationPlayer->yaw,destinationPlayer->pitch);
-			SendToPlayer(sourceResponse, sourcePlayer);
+			auto destinationPlayer = destinationClient->GetPlayer();
+			auto sourcePlayer = sourceClient->GetPlayer();
+			sourceClient->Teleport(
+				sourceResponse,
+				destinationPlayer->position,
+				destinationPlayer->yaw,
+				destinationPlayer->pitch
+			);
+			sourceClient->AppendResponse(sourceResponse);
 			Respond::ChatMessage(response, "§7Teleported " + sourcePlayer->username + " to " + destinationPlayer->username);
 		} catch (const std::exception &e) {
 			failureReason = e.what();
@@ -119,7 +130,7 @@ void Command::Teleport(Player* player) {
 }
 
 // Give any Item
-void Command::Give(Player* player) {
+void Command::Give(Client* client) {
 	if (command.size() > 1) {
 		int8_t amount = -1;
 		int8_t metadata = 0;
@@ -135,7 +146,7 @@ void Command::Give(Player* player) {
 			(itemId >= ITEM_SHOVEL_IRON && itemId < ITEM_MAX)
 		) {
 			// TODO: Find first empty slot in inventory!!
-			bool result = player->Give(response,itemId,amount,metadata);
+			bool result = client->Give(response,itemId,amount,metadata);
 			if (!result) {
 				failureReason = "Unable to give " + GetLabel(itemId);
 				return;
@@ -148,7 +159,7 @@ void Command::Give(Player* player) {
 	}
 }
 
-// Set the players health
+// Set the clients health
 void Command::Health(Player* player) {
 	if (command.size() > 1) {
 		int health = std::stoi(command[1].c_str());
@@ -162,14 +173,14 @@ void Command::Health(Player* player) {
 	}
 }
 
-// Kill the current player
+// Kill the current client
 void Command::Kill(Player* player) {
 	if (command.size() > 0) {
 		std::string username = player->username;
 		if (command.size() > 1) {
-			// Search for the player by username
+			// Search for the client by username
 			username = command[1];
-			player = Betrock::Server::Instance().FindPlayerByUsername(username);
+			player = Betrock::Server::Instance().FindClientByUsername(username)->GetPlayer();
 		}
 		if (player) {
 			player->Kill(response);
@@ -177,19 +188,19 @@ void Command::Kill(Player* player) {
 			failureReason = "";
 			return;
 		}
-		failureReason = "Player \"" + username + "\" does not exist";
+		failureReason = "client \"" + username + "\" does not exist";
 	}
 }
 
-void Command::Summon(Player* player) {
+void Command::Summon(Client* client) {
 	auto &server = Betrock::Server::Instance();
 
 	if (command.size() > 1) {
 		std::scoped_lock lock(server.GetEntityIdMutex());
 		std::string username = command[1];
 		std::vector<uint8_t> broadcastResponse;
-		Respond::NamedEntitySpawn(broadcastResponse, server.GetLatestEntityId(), username, Vec3ToInt3(player->position), 0,0, 5);
-		BroadcastToPlayers(broadcastResponse);
+		Respond::NamedEntitySpawn(broadcastResponse, server.GetLatestEntityId(), username, Vec3ToInt3(client->GetPlayer()->position), 0,0, 5);
+		BroadcastToClients(broadcastResponse);
 		Respond::ChatMessage(response, "§7Summoned " + username);
 		failureReason = "";
 	}
@@ -197,7 +208,7 @@ void Command::Summon(Player* player) {
 
 
 // Set gamerules
-void Command::Gamerule(Player* player) {
+void Command::Gamerule(Client* client) {
 	if (command.size() > 1) {
 		if (command[1] == "doDaylightCycle") {
 			doDaylightCycle = !doDaylightCycle;
@@ -213,26 +224,26 @@ void Command::Gamerule(Player* player) {
 	}
 }
 
-void Command::Kick(Player* player) {
+void Command::Kick(Client* client) {
 	if (command.size() > 0) {
-		std::string username = player->username;
+		std::string username = client->GetPlayer()->username;
 		if (command.size() > 1) {
-			// Search for the player by username
+			// Search for the client by username
 			username = command[1];
-			player = Betrock::Server::Instance().FindPlayerByUsername(username);
+			client = Betrock::Server::Instance().FindClientByUsername(username);
 		}
-		if (player) {
-			Disconnect(player, "Kicked by " + player->username);
+		if (client) {
+			client->HandleDisconnect("Kicked by " + client->GetPlayer()->username);
 			//Respond::ChatMessage(response, "§7Kicked " + kicked->username);
 			failureReason = "";
 			return;
 		}
-		failureReason = "Player \"" + username + "\" does not exist";
+		failureReason = "client \"" + username + "\" does not exist";
 	}
 }
 
-void Command::Spawn(Player* player) {
-	player->Teleport(response, Betrock::Server::Instance().GetSpawnPoint());
+void Command::Spawn(Client* client) {
+	client->Teleport(response, Betrock::Server::Instance().GetSpawnPoint());
 	failureReason = "";
 }
 
@@ -262,22 +273,23 @@ void Command::Free() {
 	failureReason = "";
 }
 
-void Command::Op(Player* player) {
+void Command::Op(Client* client) {
 	if (command.size() > 0) {
-		Respond::ChatMessage(response, "§7Opping " + player->username);
+		Respond::ChatMessage(response, "§7Opping " + client->GetPlayer()->username);
 		failureReason = "";
 	}
 }
 
-void Command::Deop(Player* player) {
+void Command::Deop(Client* client) {
 	if (command.size() > 0) {
-		Respond::ChatMessage(response, "§7De-opping " + player->username);
+		Respond::ChatMessage(response, "§7De-opping " + client->GetPlayer()->username);
 		failureReason = "";
 	}
 }
 
 // Parses commands and executes them
-void Command::Parse(std::string &rawCommand, Player* player) {
+void Command::Parse(std::string &rawCommand, Client* client) {
+	auto player = client->GetPlayer();
 	// Set these up for command parsing
 	failureReason = "Syntax";
     command.clear();
@@ -295,31 +307,31 @@ void Command::Parse(std::string &rawCommand, Player* player) {
 		if (command[0] == "time") {
 			Time();
 		} else if (command[0] == "help") {
-			Help(player);
+			Help(client);
 		} else if (command[0] == "op") {
-			Op(player);
+			Op(client);
 		} else if (command[0] == "deop") {
-			Deop(player);
+			Deop(client);
 		} else if (command[0] == "tp") {
-			Teleport(player);
+			Teleport(client);
 		} else if (command[0] == "pose") {
 			Pose(player);
 		} else if (command[0] == "sound") {
 			Sound(player);
 		} else if (command[0] == "give") {
-			Give(player);
+			Give(client);
 		} else if (command[0] == "health") {
 			Health(player);
 		} else if (command[0] == "kill") {
 			Kill(player);
 		} else if (command[0] == "summon") {
-			Summon(player);
+			Summon(client);
 		} else if (command[0] == "gamerule") {
-			Gamerule(player);
+			Gamerule(client);
 		} else if (command[0] == "kick") {
-			Kick(player);
+			Kick(client);
 		} else if (command[0] == "spawn") {
-			Spawn(player);
+			Spawn(client);
 		} else if (command[0] == "creative") {
 			Creative(player);
 		} else if (command[0] == "save") {
@@ -329,7 +341,7 @@ void Command::Parse(std::string &rawCommand, Player* player) {
 		} else if (command[0] == "free") {
 			Free();
 		} else if (command[0] == "loaded") {
-			failureReason = std::to_string(Betrock::Server::Instance().GetWorldManager(player->worldId)->world.GetNumberOfChunks());
+			failureReason = std::to_string(Betrock::Server::Instance().GetWorldManager(player->dimension)->world.GetNumberOfChunks());
 		} else if (command[0] == "used") {
 			std::stringstream ss;
 			ss << std::fixed << std::setprecision(2) << GetUsedMemoryMB();
@@ -346,5 +358,5 @@ void Command::Parse(std::string &rawCommand, Player* player) {
 	} else if (!failureReason.empty()) {
 		Respond::ChatMessage(response, "§c" + failureReason);
 	}
-	SendToPlayer(response,player);
+	client->AppendResponse(response);
 }

--- a/src/misc/command.cpp
+++ b/src/misc/command.cpp
@@ -62,13 +62,13 @@ void Command::Time() {
 	if (command.size() > 1) {
 		server.SetServerTime(std::stol(command[1]));
 
-		Respond::Time(response, serverTime);
-		Respond::ChatMessage(response, "§7Set time to " + std::to_string(serverTime));
+		Respond::Time(response, server.GetServerTime());
+		Respond::ChatMessage(response, "§7Set time to " + std::to_string(server.GetServerTime()));
 		failureReason = "";
 	}
 	// Get the time
 	if (command.size() == 1) {
-		Respond::ChatMessage(response, "§7Current Time is " + std::to_string(serverTime));
+		Respond::ChatMessage(response, "§7Current Time is " + std::to_string(server.GetServerTime()));
 		failureReason = "";
 	}
 }

--- a/src/misc/command.h
+++ b/src/misc/command.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <sstream>
 
-#include "player.h"
+#include "client.h"
 #include "helper.h"
 #include "responses.h"
 #include "world.h"
@@ -10,31 +10,33 @@
 #include "labels.h"
 #include "sysinfo.h"
 
+class Client;
+
 class Command {
     public:
-        static void Parse(std::string &rawCommand, Player* player);
+        static void Parse(std::string &rawCommand, Client* client);
     private:
         // Operator
-        static void Chunk(Player* player);
+        static void Chunk(Client* client);
         static void Creative(Player* player);
         static void Free();
-        static void Gamerule(Player* player);
-        static void Kick(Player* player);
+        static void Gamerule(Client* client);
+        static void Kick(Client* client);
         static void Save();
         static void Stop();
-        static void Summon(Player* player);
-        static void Teleport(Player* player);
+        static void Summon(Client* client);
+        static void Teleport(Client* client);
         static void Time();
         
-        static void Op(Player* player);
-        static void Deop(Player* player);
+        static void Op(Client* client);
+        static void Deop(Client* client);
 
         // Creative Player
-        static void Give(Player* player);
+        static void Give(Client* client);
         static void Health(Player* player);
-        static void Help(Player* player);
+        static void Help(Client* client);
         static void Kill(Player* player);
         static void Pose(Player* player);
         static void Sound(Player* player);
-        static void Spawn(Player* player);
+        static void Spawn(Client* client);
 };

--- a/src/objects/entity.h
+++ b/src/objects/entity.h
@@ -11,15 +11,17 @@ class Entity {
         bool onGround = true;
         float yaw = 0.0f;
         float pitch = 0.0f;
-        int8_t worldId;
+
+        int8_t dimension;
+        std::string world;
 
         int8_t health;
 
         // Connection Stats
         int32_t entityId;
 
-        Entity(int entityId, Vec3 position, int8_t worldId)
-            : entityId(entityId++), position(position), worldId(worldId) {}
+        Entity(int entityId, Vec3 position, int8_t dimension, std::string world)
+            : entityId(entityId++), position(position), dimension(dimension), world(world) {}
 
         virtual ~Entity() = default;
 

--- a/src/objects/player.cpp
+++ b/src/objects/player.cpp
@@ -2,25 +2,6 @@
 #include "client.h"
 #include <cstdint>
 
-void Player::Teleport(std::vector<uint8_t> &response, Vec3 position, float yaw, float pitch) {
-    this->position = position;
-    this->yaw = yaw;
-    this->pitch = pitch;
-    this->stance = position.y + STANCE_OFFSET;
-    this->newChunks.clear();
-    Respond::PlayerPositionLook(response, this);
-    SendChunksAroundPlayer(response,this, true);
-}
-
-void Player::Respawn(std::vector<uint8_t> &response) {
-    this->worldId = respawnWorldId;
-    Respond::Respawn(response, worldId);
-    Teleport(response, respawnPosition);
-    // After respawning, the health is automatically set back to the maximum health
-    // The Client should do this automatically
-    this->health = HEALTH_MAX;
-}
-
 void Player::SetHealth(std::vector<uint8_t> &response, int8_t health) {
     if (health > HEALTH_MAX) { health = HEALTH_MAX; }
     if (health < 0) { health = 0; }
@@ -35,150 +16,6 @@ void Player::Hurt(std::vector<uint8_t> &response, int8_t damage) {
 
 void Player::Kill(std::vector<uint8_t> &response) {
     SetHealth(response,0);
-}
-
-bool Player::TryToPutInSlot(int16_t slot, int16_t &id, int8_t &amount, int16_t &damage) {
-    // First, try to stack into existing slots
-    if (inventory[slot].id == id && inventory[slot].damage == damage) {
-        // Skip the slot if its full
-        if (inventory[slot].amount >= MAX_STACK) {
-            return false;
-        }
-        // If we fill the slot, we're done
-        if (inventory[slot].amount + amount <= MAX_STACK) {
-            inventory[slot].amount += amount;
-            return true;
-        }
-        // If we fill it but items remain, keep going
-        amount -= (MAX_STACK - inventory[slot].amount);
-        inventory[slot].amount = MAX_STACK;
-        return false;
-    }
-    // Secondly, try to stack into empty slots
-    if (inventory[slot].id == SLOT_EMPTY) {
-        inventory[slot] = { id, amount, damage };
-        return true;
-    }
-    return false;
-}
-
-bool Player::SpreadToSlots(int16_t id, int8_t amount, int16_t damage, int8_t preferredRange) {
-    if (preferredRange == 1 || preferredRange == 0) {
-        for (int8_t i = INVENTORY_HOTBAR; i <= INVENTORY_HOTBAR_LAST; i++) {
-            if (TryToPutInSlot(i, id, amount, damage)) {
-                return true;
-            }
-        }
-    }
-
-    if (preferredRange == 2 || preferredRange == 0) {
-        for (int8_t i = INVENTORY_ROW_1; i <= INVENTORY_ROW_LAST; i++) {
-            if (TryToPutInSlot(i, id, amount, damage)) {
-                return true;
-            }
-        }
-    }
-
-    // If there are still items left, inventory is full
-    return false;
-}
-
-bool Player::Give(std::vector<uint8_t> &response, int16_t item, int8_t amount, int16_t damage) {
-    // Amount is not specified
-    if (amount == -1) {
-        if (item < BLOCK_MAX) {
-            amount = MAX_STACK;
-        } else {
-            amount = 1;
-        }
-    }
-    // Look for empty slot
-    SpreadToSlots(item,amount,damage);
-    //inventory[slotId] = Item { item,amount,damage };
-    // TODO: This is a horrible solution, please find something better,
-    // like checking if the inventory was changed, and only then sending out an UpdateInventory
-    UpdateInventory(response);
-    return true;
-}
-
-bool Player::UpdateInventory(std::vector<uint8_t> &response) {
-    std::vector<Item> v(std::begin(inventory), std::end(inventory));
-    Respond::WindowItems(response, 0, v);
-    return true;
-}
-
-void Player::ChangeHeldItem(std::vector<uint8_t> &response, int16_t slotId) {
-	currentHotbarSlot = (int8_t)slotId;
-    Item i = GetHeldItem();
-    Respond::EntityEquipment(response, entityId, EQUIPMENT_SLOT_HELD, i.id, i.damage);
-}
-
-int16_t Player::GetHotbarSlot() {
-    return INVENTORY_HOTBAR + currentHotbarSlot;
-}
-
-Item Player::GetHeldItem() {
-    return inventory[GetHotbarSlot()];
-}
-
-// TODO: Implement Right-clicking
-void Player::ClickedSlot(std::vector<uint8_t> &response, int8_t windowId, int16_t slotId, bool rightClick, int16_t actionNumber, bool shift, int16_t id, int8_t amount, int16_t damage) {
-    // Shift Click Behavior
-    if (shift) {
-        // Get item
-        Item temp = inventory[slotId];
-        // Empty slot
-        inventory[slotId] = {-1,0,0};
-        if (slotId >= INVENTORY_HOTBAR) {
-            SpreadToSlots(temp.id,temp.amount,temp.damage,2);
-        } else {
-            SpreadToSlots(temp.id,temp.amount,temp.damage,1);
-        }
-    }
-    
-    // If we've clicked outside, throw the items to the ground and clear the slot.
-    if (slotId == CLICK_OUTSIDE) {
-        hoveringItem = Item {-1,0,0};
-        return;
-    }
-
-    // If something is being held
-    if (hoveringItem.id < BLOCK_STONE) {
-        Item temp = hoveringItem;
-        hoveringItem = inventory[slotId];
-        inventory[slotId] = temp;
-    } else {
-        Item temp = inventory[slotId];
-        inventory[slotId] = hoveringItem;
-        hoveringItem = temp;
-    }
-    lastClickedSlot = slotId;
-}
-
-void Player::ClearInventory() {
-    // Fill inventory with empty slots
-    for (int i = 0; i < INVENTORY_MAX_SLOTS; ++i) {
-        inventory[i] = Item{-1, 0, 0};
-    }
-}
-
-bool Player::CanDecrementHotbar() {
-    Item i = GetHeldItem();
-    if (i.id > BLOCK_AIR && i.amount > 0) {
-        return true;
-    }
-    return false;
-}
-
-void Player::DecrementHotbar(std::vector<uint8_t> &response) {
-    Item* i = &inventory[GetHotbarSlot()];
-    i->amount--;
-    if (i->amount <= 0) {
-        i->id = -1;
-        i->amount = 0;
-        i->damage = 0;
-    }
-	Respond::SetSlot(response, 0, GetHotbarSlot(), i->id, i->amount, i->damage);
 }
 
 void Player::PrintStats() {
@@ -202,7 +39,7 @@ void Player::Save() {
 	root->Put(std::make_shared<ShortTag>("Health",health));
 	root->Put(std::make_shared<ShortTag>("Air",300));
 	root->Put(std::make_shared<ByteTag>("OnGround",onGround));
-	root->Put(std::make_shared<IntTag>("Dimension",worldId));
+	root->Put(std::make_shared<IntTag>("Dimension",dimension));
 
 	auto rotationList = std::make_shared<ListTag>("Rotation");
 	rotationList->Put(std::make_shared<FloatTag>("Yaw"  ,yaw));

--- a/src/objects/player.h
+++ b/src/objects/player.h
@@ -11,13 +11,6 @@
 #define HEALTH_MAX 20
 #define STANCE_OFFSET 1.62
 
-enum class ConnectionStatus {
-    Disconnected,
-    Handshake,
-    LoggingIn,
-    Connected
-};
-
 class Player : public Entity {
     public:
         std::string username = "";
@@ -29,57 +22,31 @@ class Player : public Entity {
         bool sitting = false;
 
         // Spawn Stats
-        Vec3 respawnPosition;
-        int8_t respawnWorldId;
+        Vec3 spawnPosition;
+        int8_t spawnDimension;
+        std::string spawnWorld;
 
         // Gameplay Stats
         bool creativeMode = false;
         int8_t health = HEALTH_MAX;
-        std::vector<Int3> visibleChunks;
-        std::vector<Int3> newChunks;
-        //std::mutex visibleChunksMutex;
-        std::mutex newChunksMutex;
 
-        // Server-side inventory
-        int16_t lastClickedSlot = 0;
+        // Inventory
         Item inventory[INVENTORY_MAX_SLOTS];
-        Item hoveringItem = Item {-1,0,0};
-        int8_t currentHotbarSlot = 0;
 
-        // Connection Stats
-        // TODO: Some of this stuff should really be moved into the client!
-        int64_t lastPacketTime = 0;
-        int client_fd;
-        ConnectionStatus connectionStatus = ConnectionStatus::Disconnected;
-        Vec3 lastChunkUpdatePosition;
-        Vec3 lastTickPosition;
         void ClearInventory();
 
-        Player(int client_fd, int &entityId, Vec3 position, int8_t worldId, Vec3 respawnPosition, int8_t respawnWorldId)
-            : Entity(entityId++, position, worldId),
-            respawnPosition(respawnPosition),
-            respawnWorldId(respawnWorldId), 
-            client_fd(client_fd),
-            connectionStatus(ConnectionStatus::Disconnected)
+        Player(int &entityId, Vec3 position, int8_t dimension, std::string world, Vec3 spawnPosition, int8_t spawnDimension, std::string spawnWorld)
+            : Entity(entityId++, position, dimension, world),
+            spawnPosition(spawnPosition),
+            spawnDimension(spawnDimension),
+            spawnWorld(spawnWorld)
         {
             ClearInventory();
         }
 
-        void Teleport(std::vector<uint8_t> &response, Vec3 position, float yaw = 0, float pitch = 0);
-        void Respawn(std::vector<uint8_t> &response);
         void SetHealth(std::vector<uint8_t> &response, int8_t health);
         void Hurt(std::vector<uint8_t> &response, int8_t damage);
         void Kill(std::vector<uint8_t> &response);
-        bool TryToPutInSlot(int16_t slot, int16_t &id, int8_t &amount, int16_t &damage);
-        bool SpreadToSlots(int16_t item, int8_t amount, int16_t damage, int8_t preferredRange = 0);
-        void ClickedSlot(std::vector<uint8_t> &response, int8_t windowId, int16_t slotId, bool rightClick, int16_t actionNumber, bool shift, int16_t id, int8_t amount, int16_t damage);
-        bool Give(std::vector<uint8_t> &response, int16_t item, int8_t amount = -1, int16_t damage = 0);
-        bool UpdateInventory(std::vector<uint8_t> &response);
-        void ChangeHeldItem(std::vector<uint8_t> &response, int16_t slotId);
-        int16_t GetHotbarSlot();
-        Item GetHeldItem();
-        bool CanDecrementHotbar();
-        void DecrementHotbar(std::vector<uint8_t> &response);
         void PrintStats();
         void Save();
         bool Load();

--- a/src/objects/player.h
+++ b/src/objects/player.h
@@ -33,16 +33,12 @@ class Player : public Entity {
         // Inventory
         Item inventory[INVENTORY_MAX_SLOTS];
 
-        void ClearInventory();
-
         Player(int &entityId, Vec3 position, int8_t dimension, std::string world, Vec3 spawnPosition, int8_t spawnDimension, std::string spawnWorld)
             : Entity(entityId++, position, dimension, world),
             spawnPosition(spawnPosition),
             spawnDimension(spawnDimension),
             spawnWorld(spawnWorld)
-        {
-            ClearInventory();
-        }
+        {}
 
         void SetHealth(std::vector<uint8_t> &response, int8_t health);
         void Hurt(std::vector<uint8_t> &response, int8_t damage);

--- a/src/objects/world.cpp
+++ b/src/objects/world.cpp
@@ -78,8 +78,8 @@ void World::FreeUnseenChunks() {
     
         // Check if any player has this chunk hash in their visibleChunks
         bool isVisible = false;
-        for (const auto& player : Betrock::Server::Instance().GetConnectedPlayers()) {  // Assuming players is a vector or container of Player objects
-            if (std::find(player->visibleChunks.begin(), player->visibleChunks.end(), DecodeChunkHash(hash)) != player->visibleChunks.end()) {
+        for (const auto& c : Betrock::Server::Instance().GetConnectedClients()) {
+            if (c->ChunkIsVisible(pos)) {
                 isVisible = true;
                 break;
             }

--- a/src/objects/worldManager.cpp
+++ b/src/objects/worldManager.cpp
@@ -2,16 +2,16 @@
 
 #include "server.h"
 
-QueueChunk::QueueChunk(Int3 position, Player* requestPlayer) {
+QueueChunk::QueueChunk(Int3 position, Client* requestClient) {
     this->position = position;
-    AddPlayer(requestPlayer);
+    AddClient(requestClient);
 }
 
-void QueueChunk::AddPlayer(Player* requestPlayer) {
-    requestedPlayers.push_back(requestPlayer);
+void QueueChunk::AddClient(Client* requestClient) {
+    requestedClients.push_back(requestClient);
 }
 
-void WorldManager::AddChunkToQueue(int32_t x, int32_t z, Player* requestPlayer) {
+void WorldManager::AddChunkToQueue(int32_t x, int32_t z, Client* requestClient) {
     std::lock_guard<std::mutex> lock(queueMutex);  // Ensure thread safety
 
     auto hash = GetChunkHash(x, z);  // Compute hash
@@ -22,7 +22,7 @@ void WorldManager::AddChunkToQueue(int32_t x, int32_t z, Player* requestPlayer) 
     }
 
     // Add to queue and track position
-    chunkQueue.emplace(Int3{x, 0, z}, requestPlayer);
+    chunkQueue.emplace(Int3{x, 0, z}, requestClient);
     chunkPositions.insert(hash);
 }
 
@@ -98,11 +98,11 @@ void WorldManager::WorkerThread() {
 		// Try to load chunk
         GetChunk(cq.position.x, cq.position.z,generator);
 
-        std::scoped_lock lock(Betrock::Server::Instance().GetConnectedPlayerMutex());
-        for (Player* p : cq.requestedPlayers) {
-            if (p) {
-                std::lock_guard<std::mutex> lock(p->newChunksMutex);
-                p->newChunks.push_back(cq.position);
+        std::scoped_lock lock(Betrock::Server::Instance().GetConnectedClientMutex());
+        for (auto c : cq.requestedClients) {
+            if (c) {
+                std::lock_guard<std::mutex> lock(c->GetNewChunksMutex());
+                c->AddNewChunk(cq.position);
             }
         }
     }

--- a/src/objects/worldManager.h
+++ b/src/objects/worldManager.h
@@ -8,14 +8,17 @@
 #include "world.h"
 #include "generator.h"
 #include "coms.h"
+#include "client.h"
+
+class Client;  // Forward declaration
 
 class QueueChunk {
     public:
         Int3 position;
-        std::vector<Player*> requestedPlayers;
-        QueueChunk() : position(Int3()), requestedPlayers() {}
-        QueueChunk(Int3 position, Player* requestPlayer = nullptr);
-        void AddPlayer(Player* requestPlayer);
+        std::vector<Client*> requestedClients;
+        QueueChunk() : position(Int3()), requestedClients() {}
+        QueueChunk(Int3 position, Client* requestClient = nullptr);
+        void AddClient(Client* requestClient);
 };
 
 class WorldManager {
@@ -32,7 +35,7 @@ class WorldManager {
         void GetChunk(int32_t x, int32_t z, Generator &generator);
     public:
         World world;
-        void AddChunkToQueue(int32_t x, int32_t z, Player* requestPlayer = nullptr);
+        void AddChunkToQueue(int32_t x, int32_t z, Client* requestClient = nullptr);
         void GenerateQueuedChunks();
         void ForceGenerateChunk(int32_t x, int32_t z);
         void SetSeed(int64_t seed);

--- a/src/scripts/terrain/perlin.lua
+++ b/src/scripts/terrain/perlin.lua
@@ -16,7 +16,7 @@ function PlaceTree(c,x,y,z)
         c[index(x,y+5+h,z-1)] = {18,0}
     end
 
-    for h = 0, 5 do
+    for h = 1, 5 do
         c[index(x,y+h,z)] = {17,0}
     end
     c[index(x,y+6,z)] = {18,0}

--- a/src/scripts/terrain/skylands.lua
+++ b/src/scripts/terrain/skylands.lua
@@ -16,7 +16,7 @@ function PlaceTree(c,x,y,z)
         c[index(x,y+5+h,z-1)] = {18,0}
     end
 
-    for h = 0, 5 do
+    for h = 1, 5 do
         c[index(x,y+h,z)] = {17,0}
     end
     c[index(x,y+6,z)] = {18,0}

--- a/src/scripts/terrain/worley.lua
+++ b/src/scripts/terrain/worley.lua
@@ -19,7 +19,7 @@ function PlaceTree(c,x,y,z)
         c[index(x,y+5+h,z-1)] = {18,0}
     end
 
-    for h = 0, 5 do
+    for h = 1, 5 do
         c[index(x,y+h,z)] = {17,0}
     end
     c[index(x,y+6,z)] = {18,0}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -9,11 +9,13 @@ void Server::Stop() noexcept { this->alive = false; }
 
 bool Server::IsAlive() const noexcept { return this->alive; }
 
-int8_t Server::GetSpawnWorld() const noexcept { return this->spawnWorld; }
+int8_t Server::GetSpawnDimension() const noexcept { return this->spawnDimension; }
+
+std::string Server::GetSpawnWorld() const noexcept { return this->spawnWorld; }
 
 int Server::GetServerFd() const noexcept { return this->serverFd; }
 
-std::vector<Player *> &Server::GetConnectedPlayers() noexcept { return this->connectedPlayers; }
+std::vector<Client *> &Server::GetConnectedClients() noexcept { return this->connectedClients; }
 
 int32_t &Server::GetLatestEntityId() noexcept { return this->latestEntityId; }
 
@@ -41,7 +43,7 @@ World *Server::GetWorld(int8_t worldId) const {
 
 const Vec3 &Server::GetSpawnPoint() const noexcept { return this->spawnPoint; }
 
-std::mutex &Server::GetConnectedPlayerMutex() noexcept { return this->connectedPlayersMutex; }
+std::mutex &Server::GetConnectedClientMutex() noexcept { return this->connectedClientsMutex; }
 
 std::mutex &Server::GetEntityIdMutex() noexcept { return this->entityIdMutex; }
 
@@ -49,15 +51,15 @@ void Server::SetServerTime(uint64_t serverTime) { this->serverTime = serverTime;
 
 void Server::SetSpawnPoint(const Vec3 &spawnPoint) noexcept { this->spawnPoint = spawnPoint; }
 
-Player *Server::FindPlayerByUsername(std::string_view username) const {
-	auto player = std::ranges::find_if(std::ranges::views::all(this->connectedPlayers),
-									   [&username](const auto &p) { return p->username == username; });
+Client *Server::FindClientByUsername(std::string_view username) const {
+	auto client = std::ranges::find_if(std::ranges::views::all(this->connectedClients),
+									   [&username](const auto &c) { return c->GetPlayer()->username == username; });
 
-	if (player == this->connectedPlayers.end()) {
+	if (client == this->connectedClients.end()) {
 		return nullptr;
 	}
 
-	return std::to_address(*player);
+	return std::to_address(*client);
 }
 
 void Server::AddWorldManager(int8_t worldId) {
@@ -84,9 +86,9 @@ void Server::AddWorldManager(int8_t worldId) {
 
 void Server::SaveAll() {
 	Betrock::Logger::Instance().Info("Saving...");
-	for (Player* p : GetConnectedPlayers()){
-		if (p) {
-			Disconnect(p,"Goodbye!");
+	for (auto c : GetConnectedClients()){
+		if (c) {
+			c->HandleDisconnect("Goodbye!");
 		}
 	}
 	for (const auto &[key, wm] : worldManagers) {
@@ -100,6 +102,7 @@ void Server::FreeAll() {
 	for (const auto &[key, wm] : worldManagers) {
 		wm->world.FreeUnseenChunks();
 	}
+	Betrock::Logger::Instance().Info("Freed Chunks");
 }
 
 void Server::PrepareForShutdown() {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -15,7 +15,7 @@ std::string Server::GetSpawnWorld() const noexcept { return this->spawnWorld; }
 
 int Server::GetServerFd() const noexcept { return this->serverFd; }
 
-std::vector<Client *> &Server::GetConnectedClients() noexcept { return this->connectedClients; }
+std::vector<std::shared_ptr<Client>> &Server::GetConnectedClients() noexcept { return this->connectedClients; }
 
 int32_t &Server::GetLatestEntityId() noexcept { return this->latestEntityId; }
 

--- a/src/server.h
+++ b/src/server.h
@@ -90,8 +90,6 @@ class Server {
 		struct sockaddr_in address;
 		int addrlen = sizeof(address);
 
-		std::vector<std::jthread> clientThreadPool;
-
 		while (server.alive) {
 			// Accept connections
 			int client_fd = accept(server.serverFd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
@@ -107,10 +105,6 @@ class Server {
 				auto client = std::make_shared<Client>(client_fd);
 				client->SetConnectionStatus(ConnectionStatus::Handshake);
 
-				clientThreadPool.emplace_back([client]() {
-					client->HandleClient();
-				});
-
 				// Add this new client to the list of connected Players
 				{
 					std::scoped_lock lockConnectedClients(server.connectedClientsMutex);
@@ -122,16 +116,9 @@ class Server {
 				// yell at us
 			}
 		}
-
-		// Join and clean up the threads
-		for (auto &clientThread : clientThreadPool) {
-			if (clientThread.joinable()) {
-				clientThread.join();
-			}
-		}
 	}
 
-  private:
+  	private:
 	Server() = default;
 	~Server() = default;
 

--- a/src/server.h
+++ b/src/server.h
@@ -110,10 +110,8 @@ class Server {
 					std::scoped_lock lockConnectedClients(server.connectedClientsMutex);
 					server.connectedClients.push_back(client);
 				}
-				// Let each player have their own thread
-				// TODO: Make this non-cancerous, and close player threads upon disconnect
-				// IDEA: disconnect player socket in their destructor, when we try to read from a closed socket epoll will
-				// yell at us
+				std::jthread clientThread(&Client::HandleClient, client);
+				clientThread.detach();
 			}
 		}
 	}


### PR DESCRIPTION
- Made Client and Player more separate, now the Client is responsible for handling all networking related things, while the player is only an extension of the Entity class, to hold player-unique variables.
- The Player is now fully controlled by the Client object
- Access to the Player is now done through the client
- Client is now responsible for handling the inventory
- Client is now responsible for handling the connection status, visible chunks, to-be-sent chunks, clientFd etc.
- A lot of functionality of coms is now directly in the client
- Made start on implementing distinction between dimensions and worlds/levels
- Fixed trees generating one block into the ground in all lua scripts that use the shared PlaceTree function
- Clients are now stored as shared_ptrs directly in the Server as part of a vector, instead of players.