### PR TITLE
v0.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 cmake_policy(SET CMP0072 NEW)
 
-project(BetrockServer VERSION 0.2.0)
+project(BetrockServer VERSION 0.2.1)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/client.h
+++ b/src/client.h
@@ -80,6 +80,7 @@ class Client : public std::enable_shared_from_this<Client> {
         bool HandleCloseWindow();
         bool HandleWindowClick();
         void HandleLegacyPing();
+        bool HandleDisconnect();
 
         // Helpers
         void Respawn(std::vector<uint8_t> &response);
@@ -105,7 +106,7 @@ class Client : public std::enable_shared_from_this<Client> {
 
         Client(int clientFd) : clientFd(clientFd) {}
         void HandleClient();
-        bool HandleDisconnect(std::string disconnectMessage = "");
+        void DisconnectClient(std::string disconnectMessage = "");
 
         bool Give(std::vector<uint8_t> &response, int16_t item, int8_t amount = -1, int16_t damage = 0);
         bool UpdateInventory(std::vector<uint8_t> &response);

--- a/src/coms/coms.cpp
+++ b/src/coms/coms.cpp
@@ -30,6 +30,6 @@ void DisconnectAllClients(std::string message) {
 	std::scoped_lock lock(server.GetConnectedClientMutex());
     for (auto client : server.GetConnectedClients()) {
         //Disconnect(player, message);
-		client->HandleDisconnect(message);
+		client->DisconnectClient(message);
     }
 }

--- a/src/misc/command.cpp
+++ b/src/misc/command.cpp
@@ -233,7 +233,7 @@ void Command::Kick(Client* client) {
 			client = Betrock::Server::Instance().FindClientByUsername(username);
 		}
 		if (client) {
-			client->HandleDisconnect("Kicked by " + client->GetPlayer()->username);
+			client->DisconnectClient("Kicked by " + client->GetPlayer()->username);
 			//Respond::ChatMessage(response, "§7Kicked " + kicked->username);
 			failureReason = "";
 			return;

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -2,9 +2,9 @@
 #pragma once
 #define PROJECT_VERSION_MAJOR 0
 #define PROJECT_VERSION_MINOR 2
-#define PROJECT_VERSION_PATCH 0
-#define PROJECT_VERSION_STRING "0.2.0"
+#define PROJECT_VERSION_PATCH 1
+#define PROJECT_VERSION_STRING "0.2.1"
 
 #define PROJECT_NAME "BetrockServer"
 
-#define PROJECT_NAME_VERSION "BetrockServer 0.2.0"
+#define PROJECT_NAME_VERSION "BetrockServer 0.2.1"

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -84,11 +84,15 @@ void Server::AddWorldManager(int8_t worldId) {
 	}
 }
 
-void Server::SaveAll() {
+void Server::SaveAll(bool shutdown) {
 	Betrock::Logger::Instance().Info("Saving...");
-	for (auto c : GetConnectedClients()){
-		if (c) {
-			c->HandleDisconnect("Goodbye!");
+	if (shutdown) {
+		DisconnectAllClients("Server closed");
+	} else {
+		for (auto c : GetConnectedClients()){
+			if (c) {
+					c->GetPlayer()->Save();
+			}
 		}
 	}
 	for (const auto &[key, wm] : worldManagers) {
@@ -109,7 +113,7 @@ void Server::PrepareForShutdown() {
 	alive = false;
 	// Save all active worlds
 	if (!debugDisableSaveLoad) {
-		SaveAll();
+		SaveAll(true);
 	}
 	//DisconnectAllPlayers("Server closed!");
 	close(serverFd);

--- a/src/server.h
+++ b/src/server.h
@@ -72,7 +72,7 @@ class Server {
 	// add a new world manager (and also a new world)
 	void AddWorldManager(int8_t world_id);
 
-	void SaveAll();
+	void SaveAll(bool shutdown = false);
 
 	void FreeAll();
 


### PR DESCRIPTION
- Fixed #56. This was caused by inconsistent disconnect logic
- HandleDisconnect is now only responsible for Handling the disconnect message and passing it to DisconnectClient.
- Additionally, HandleDisconnect is now private
- DisconnectClient is now responsible for getting everything set up, so a client entity is destroyed for all connected players
- All external uses of HandleDisconnect have been replaced by DisconnectClient
- Players now no longer get kicked when saving everything via `/save`. This was caused by HandleDisconnect being called on all players when it was time to save. This was done under the assumption that SaveAll would only ever be run when the Server is shut down, and since a player saves their Nbt Data when disconnecting, this seemed like a safe way to do this.
- SaveAll now has a "shutdown" parameter, indicating whether all connected clients should be disconnected.