### PR TITLE
v0.2.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,4 +21,4 @@ assignees: ''
 **System Info:**
 - OS (Server): 
 - OS (Client): 
-- Version: v0.2.2 (BRANCH/COMMIT_HASH)
+- Version: v0.2.3 (BRANCH/COMMIT_HASH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,15 +110,13 @@ endif ()
 
 set(CMAKE_SYSTEM_NAME Linux)
 
-# TODO: Get Windows Target working
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(CMAKE_C_COMPILER i686-w64-mingw32-gcc)
-    set(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
-    set(CMAKE_RC_COMPILER i686-w64-mingw32-windres)
-    set(CMAKE_RANLIB i686-w64-mingw32-ranlib)
-else()
-    # Apply AddressSanitizer to all build types
-endif()
+# Maybe get Windows Target working
+#if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+#    set(CMAKE_C_COMPILER i686-w64-mingw32-gcc)
+#    set(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
+#    set(CMAKE_RC_COMPILER i686-w64-mingw32-windres)
+#    set(CMAKE_RANLIB i686-w64-mingw32-ranlib)
+#endif()
 
 target_link_libraries(
     BetrockServer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 cmake_policy(SET CMP0072 NEW)
 
-project(BetrockServer VERSION 0.2.2)
+project(BetrockServer VERSION 0.2.3)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -853,10 +853,10 @@ void Client::DisconnectClient(std::string disconnectMessage) {
 }
 
 void Client::AppendResponse(std::vector<uint8_t> &addition) {
-	//Betrock::Logger::Instance().Debug("Appended\n" + Uint8ArrayToHexDump(&addition[0], addition.size()));
-	response.insert(response.end(), addition.begin(), addition.end());
-	SendResponse(true);
-	//Betrock::Logger::Instance().Debug("After appending\n" + Uint8ArrayToHexDump(&response[0], response.size()));
+	if (!addition.empty()) {
+		response.insert(response.end(), addition.begin(), addition.end());
+		SendResponse(true);
+	}
 }
 
 // Send the contents of response to the Client

--- a/src/misc/commands/command.cpp
+++ b/src/misc/commands/command.cpp
@@ -210,13 +210,12 @@ void Command::Summon(Client* client) {
 		std::scoped_lock lock(server.GetEntityIdMutex());
 		std::string username = command[1];
 		std::vector<uint8_t> broadcastResponse;
-		Respond::NamedEntitySpawn(broadcastResponse, server.GetLatestEntityId(), username, Vec3ToInt3(client->GetPlayer()->position), 0,0, 5);
+		Respond::NamedEntitySpawn(broadcastResponse, server.GetLatestEntityId(), username, Vec3ToEntityInt3(client->GetPlayer()->position), 0,0, 5);
 		BroadcastToClients(broadcastResponse);
 		Respond::ChatMessage(response, "§7Summoned " + username);
 		failureReason = "";
 	}
 }
-
 
 // Set gamerules
 void Command::Gamerule(Client* client) {

--- a/src/misc/commands/command.cpp
+++ b/src/misc/commands/command.cpp
@@ -3,6 +3,8 @@
 #include "client.h"
 #include "server.h"
 
+#include "help.h"
+
 std::vector<uint8_t> response;
 std::vector<std::string> command;
 std::string failureReason;
@@ -10,7 +12,18 @@ std::string failureReason;
 // Send the client help pages
 // Do these in markdown(?)
 void Command::Help() {
-	Respond::ChatMessage(response, "§7Current " + std::string(PROJECT_NAME) + " version is "  + std::string(PROJECT_VERSION_FULL_STRING));
+	Respond::ChatMessage(response, "§7-- All commands --");
+	std::string msg = "§7";
+	for (int i = 0; i < commandListing.size(); i++) {
+		msg += commandListing[i];
+		if (i < commandListing.size()-1) {
+			msg += ", ";
+		}
+		if (msg.size() > 40 || i == commandListing.size()-1) {
+			Respond::ChatMessage(response, msg);
+			msg = "§7";
+		}
+	}
 	failureReason = "";
 	return;
 }

--- a/src/misc/commands/help.h
+++ b/src/misc/commands/help.h
@@ -1,0 +1,7 @@
+// Command listing
+std::vector<std::string> commandListing = {
+    "creative","free","gamerule","kick","save",
+    "stop","summon","tp","time","deop","op",
+    "give","health","help","kill","pose","sound",
+    "spawn","version","loaded","used"
+};

--- a/src/misc/commands/help.md
+++ b/src/misc/commands/help.md
@@ -50,7 +50,7 @@ Gets/sets the server time
 ## op
 Grants operator from the passed player
 ```
-/deop <username>
+/op <username>
 ```
 ## deop
 Removes operator from the passed player
@@ -89,5 +89,11 @@ Plays the passed sound id
 ```
 ## spawn
 Teleports the player to spawn
+```
+/spawn
+```
 ## version
 Prints the server version
+```
+/version
+```

--- a/src/misc/helpers/datatypes.h
+++ b/src/misc/helpers/datatypes.h
@@ -25,6 +25,12 @@ struct Block {
 // TODO: Add a "modified" tag to a chunk to see if we need to bother re-saving it(?)
 struct Chunk {
     struct Block blocks[CHUNK_WIDTH_X*CHUNK_WIDTH_Z*CHUNK_HEIGHT];
+    // This describes the number of clients that can see this chunk.
+    // If this hits 0, the chunk is invisible and can be removed
+    uint16_t viewers = 0;
+
+    // A non-populated chunk still needs to be popualated with foliage
+    bool populated = false;
 };
 
 // Custom Types

--- a/src/misc/helpers/datatypes.h
+++ b/src/misc/helpers/datatypes.h
@@ -22,6 +22,9 @@ struct Block {
     uint8_t lightSky = 0;
 };
 
+#define OLD_CHUNK_FILE_EXTENSION ".cnk"
+#define CHUNK_FILE_EXTENSION ".ncnk"
+
 // TODO: Add a "modified" tag to a chunk to see if we need to bother re-saving it(?)
 struct Chunk {
     struct Block blocks[CHUNK_WIDTH_X*CHUNK_WIDTH_Z*CHUNK_HEIGHT];

--- a/src/misc/helpers/helper.cpp
+++ b/src/misc/helpers/helper.cpp
@@ -2,9 +2,9 @@
 
 Vec3 Int3ToVec3(Int3 i) {
 	Vec3 v = {
-		(double)i.x,
+		(double)i.x+0.5,
 		(double)i.y,
-		(double)i.z
+		(double)i.z+0.5
 	};
 	return v;
 }

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -4,9 +4,9 @@
 #define PROJECT_VERSION_MINOR 2
 #define PROJECT_VERSION_PATCH 3
 #define PROJECT_VERSION_STRING "0.2.3"
-#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/114b375)"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/de8538c)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "114b375"
+#define PROJECT_GIT_COMMIT "de8538c"
 #define PROJECT_GIT_BRANCH "latest"
 #define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/114b375)"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/de8538c)"

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -2,11 +2,11 @@
 #pragma once
 #define PROJECT_VERSION_MAJOR 0
 #define PROJECT_VERSION_MINOR 2
-#define PROJECT_VERSION_PATCH 2
-#define PROJECT_VERSION_STRING "0.2.2"
-#define PROJECT_VERSION_FULL_STRING "0.2.2 (latest/6ad68e9)"
+#define PROJECT_VERSION_PATCH 3
+#define PROJECT_VERSION_STRING "0.2.3"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/2839cfa)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "6ad68e9"
+#define PROJECT_GIT_COMMIT "2839cfa"
 #define PROJECT_GIT_BRANCH "latest"
-#define PROJECT_NAME_VERSION "BetrockServer 0.2.2"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.2 (latest/6ad68e9)"
+#define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/2839cfa)"

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -4,9 +4,9 @@
 #define PROJECT_VERSION_MINOR 2
 #define PROJECT_VERSION_PATCH 3
 #define PROJECT_VERSION_STRING "0.2.3"
-#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/2839cfa)"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/35058c7)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "2839cfa"
+#define PROJECT_GIT_COMMIT "35058c7"
 #define PROJECT_GIT_BRANCH "latest"
 #define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/2839cfa)"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/35058c7)"

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -4,9 +4,9 @@
 #define PROJECT_VERSION_MINOR 2
 #define PROJECT_VERSION_PATCH 3
 #define PROJECT_VERSION_STRING "0.2.3"
-#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/35058c7)"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/b61442a)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "35058c7"
+#define PROJECT_GIT_COMMIT "b61442a"
 #define PROJECT_GIT_BRANCH "latest"
 #define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/35058c7)"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/b61442a)"

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -4,9 +4,9 @@
 #define PROJECT_VERSION_MINOR 2
 #define PROJECT_VERSION_PATCH 3
 #define PROJECT_VERSION_STRING "0.2.3"
-#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/b61442a)"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/114b375)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "b61442a"
+#define PROJECT_GIT_COMMIT "114b375"
 #define PROJECT_GIT_BRANCH "latest"
 #define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/b61442a)"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/114b375)"

--- a/src/misc/version.h
+++ b/src/misc/version.h
@@ -4,9 +4,9 @@
 #define PROJECT_VERSION_MINOR 2
 #define PROJECT_VERSION_PATCH 3
 #define PROJECT_VERSION_STRING "0.2.3"
-#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/de8538c)"
+#define PROJECT_VERSION_FULL_STRING "0.2.3 (latest/edeb0ce)"
 #define PROJECT_NAME "BetrockServer"
-#define PROJECT_GIT_COMMIT "de8538c"
+#define PROJECT_GIT_COMMIT "edeb0ce"
 #define PROJECT_GIT_BRANCH "latest"
 #define PROJECT_NAME_VERSION "BetrockServer 0.2.3"
-#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/de8538c)"
+#define PROJECT_NAME_VERSION_FULL "BetrockServer 0.2.3 (latest/edeb0ce)"

--- a/src/objects/world.cpp
+++ b/src/objects/world.cpp
@@ -112,7 +112,8 @@ bool World::LoadChunk(int32_t x, int32_t z) {
         return false;
     }
 
-    auto readRoot = NbtReadFromFile(entryPath,NBT_UNCOMPRESSED);
+    // TODO: We can know the uncompressed size beforehand, since its always the same.
+    auto readRoot = NbtReadFromFile(entryPath,NBT_ZLIB,50);
     //readRoot->NbtPrintData();
 
     auto root = std::dynamic_pointer_cast<CompoundTag>(readRoot);
@@ -179,7 +180,7 @@ void World::SaveChunk(int32_t x, int32_t z, const Chunk* chunk) {
     level->Put(std::make_shared<IntTag>("zPos",x));
     level->Put(std::make_shared<IntTag>("xPos",z));
     
-    NbtWriteToFile(filePath,root,NBT_UNCOMPRESSED);
+    NbtWriteToFile(filePath,root,NBT_ZLIB);
 }
 
 void World::PlaceBlock(Int3 position, int8_t type, int8_t meta) {

--- a/src/objects/world.h
+++ b/src/objects/world.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <mutex>
 #include <fstream>
+#include <memory>
+#include <cstdint>
 #include <filesystem>
 
 #include "helper.h"
@@ -23,6 +25,10 @@ class World {
         void Save();
         int GetNumberOfChunks();
         std::unique_ptr<char[]> GetChunkData(Int3 position);
+        std::array<int8_t, CHUNK_WIDTH_X * CHUNK_HEIGHT * CHUNK_WIDTH_Z> GetChunkBlocks(const Chunk* c);
+        std::array<int8_t, CHUNK_WIDTH_X * CHUNK_HEIGHT * CHUNK_WIDTH_Z> GetChunkMeta(const Chunk* c);
+        std::array<int8_t, CHUNK_WIDTH_X * (CHUNK_HEIGHT/2) * CHUNK_WIDTH_Z> GetChunkBlockLight(const Chunk* c);
+        std::array<int8_t, CHUNK_WIDTH_X * (CHUNK_HEIGHT/2) * CHUNK_WIDTH_Z> GetChunkSkyLight(const Chunk* c);
         void PlaceBlock(Int3 position, int8_t type, int8_t meta);
         Block BreakBlock(Int3 position);
         Block* GetBlock(Int3 position);

--- a/src/objects/world.h
+++ b/src/objects/world.h
@@ -37,6 +37,7 @@ class World {
         void FreeUnseenChunks();
         void SaveChunk(int32_t x, int32_t z, const Chunk* chunk);
         bool LoadChunk(int32_t x, int32_t z);
-        bool ChunkFileExists(int32_t x, int32_t z);
+        bool LoadOldChunk(int32_t x, int32_t z);
+        bool ChunkFileExists(int32_t x, int32_t z, std::string extension = std::string(CHUNK_FILE_EXTENSION));
         bool ChunkExists(int32_t x, int32_t z);
 };

--- a/src/objects/worldManager.cpp
+++ b/src/objects/worldManager.cpp
@@ -107,7 +107,9 @@ void WorldManager::WorkerThread() {
 void WorldManager::GetChunk(int32_t x, int32_t z, Generator &generator) {
     if (world.ChunkFileExists(x,z)) {
         world.LoadChunk(x,z);
-    }  else {
+    } else if (world.ChunkFileExists(x,z,OLD_CHUNK_FILE_EXTENSION)) {
+        world.LoadOldChunk(x,z);
+    } else {
         Chunk c = generator.GenerateChunk(x,z);
         world.AddChunk(x, z, c);
     }

--- a/src/objects/worldManager.cpp
+++ b/src/objects/worldManager.cpp
@@ -18,6 +18,7 @@ void WorldManager::AddChunkToQueue(int32_t x, int32_t z, Client* requestClient) 
 
     if (chunkPositions.find(hash) != chunkPositions.end()) {
         // Chunk is already in the queue, no need to add it again
+        // TODO: Add other requestClient to chunk!!
         return;
     }
 

--- a/src/plugins/terrain/generator.cpp
+++ b/src/plugins/terrain/generator.cpp
@@ -76,8 +76,8 @@ Chunk Generator::GenerateChunk(int32_t cX, int32_t cZ) {
                     lua_rawgeti(L, -2, 2);
     
                     if (lua_isnumber(L, -2) && lua_isnumber(L, -1)) {
-                        c.blocks[i].type = lua_tointeger(L, -2);
-                        c.blocks[i].meta = lua_tointeger(L, -1);
+                        c.blocks[i-1].type = lua_tointeger(L, -2);
+                        c.blocks[i-1].meta = lua_tointeger(L, -1);
                     }
     
                     lua_pop(L, 2);  // Pop both numbers
@@ -88,7 +88,6 @@ Chunk Generator::GenerateChunk(int32_t cX, int32_t cZ) {
             lua_pop(L, 1);  // Pop the table itself
         }
     }
-
     CalculateChunkLight(&c);
     return c;
 }
@@ -218,25 +217,25 @@ int lua_Index(lua_State *L) {
     if (x < 0) {
         x = 0;
     }
-    if (x > CHUNK_WIDTH_X) {
-        x = CHUNK_WIDTH_X;
+    if (x >= CHUNK_WIDTH_X) {
+        x = CHUNK_WIDTH_X-1;
     }
     if (z < 0) {
         z = 0;
     }
-    if (z > CHUNK_WIDTH_Z) {
-        z = CHUNK_WIDTH_Z;
+    if (z >= CHUNK_WIDTH_Z) {
+        z = CHUNK_WIDTH_Z-1;
     }
     if (y < 0) {
         y = 0;
     }
-    if (y > CHUNK_HEIGHT) {
-        y = CHUNK_HEIGHT;
+    if (y >= CHUNK_HEIGHT) {
+        y = CHUNK_HEIGHT-1;
     }
     Int3 pos = Int3{x,y,z};
 
     // Call Between and push the result
-    int32_t result = GetBlockIndex(pos);
+    int32_t result = GetBlockIndex(pos)+1;
     lua_pushnumber(L, result);
 
     return 1; // One return value on the Lua stack


### PR DESCRIPTION
- Bumped Version to 0.2.3
- Fixed crash when addition vector was empty in `Client::AppendResponse`
- The `/help` command now lists all available commands
- Fixed `/summon <username>`
- Chunk format has been reworked to be closer to what's inside McRegion formatted files. Instead of raw binary data it now contains ZLib Compressed NBT Data. This also allows one to store more metadata for a chunk.
- `Int3ToVec3` now automatically adds 0.5 along the X and Z axis to center the coordinate to the block
- `ChunkFileExists` can now take an optional Extension Parameter
- Fixed the block at the (0,0,0) position within a chunk to be missing
- Fixed bounds check of `lua_index`